### PR TITLE
Revise map folio process

### DIFF
--- a/public/cantusdata/management/commands/import_folio_mapping.py
+++ b/public/cantusdata/management/commands/import_folio_mapping.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
             action="store",
             nargs="+",
             dest="manuscript_ids",
-            help="Identifies manuscripts being mapped. Provided in same order as --mapping_csvs",
+            help="Identifies manuscripts being mapped. Provided in same order as --mapping_data",
         )
         parser.add_argument(
             "--mapping_data",
@@ -42,7 +42,7 @@ class Command(BaseCommand):
             action="store",
             dest="csvs_path",
             default="data_dumps/folio_mapping",
-            help="Directory where mapping_csvs are found. Defaults to ./data_dumps/folio_mapping",
+            help="Directory where mapping_data csvs are found. Defaults to ./data_dumps/folio_mapping",
         )
 
     def handle(self, *args, **options):
@@ -65,7 +65,7 @@ class Command(BaseCommand):
             if isinstance(input_data, str):
                 try:
                     mapping_data = csv.DictReader(
-                        open(f"{options['csvs_path']}/{input_data}", "rU")
+                        open(f"{options['csvs_path']}/{input_data}", "r")
                     )
                 except IOError:
                     raise IOError(

--- a/public/cantusdata/management/commands/import_folio_mapping.py
+++ b/public/cantusdata/management/commands/import_folio_mapping.py
@@ -2,20 +2,33 @@ from django.core.management.base import BaseCommand
 from cantusdata.models.folio import Folio
 from cantusdata.models.manuscript import Manuscript
 from django.core.management import call_command
-from optparse import make_option
 import csv
-
 
 class Command(BaseCommand):
     """
     Import a folio mapping (CSV file)
     Save that mapping to both django and Solr (through signals)
-
-    Usage: See 'help' below
     """
 
     def add_arguments(self, parser):
-        parser.add_argument("args", nargs=2)
+        parser.add_argument(
+            "--manuscripts",
+            action = "store",
+            nargs = "+",
+            dest = "manuscript_ids",
+            help = "Identifies manuscripts being mapped. Provided in same order as --mapping_csvs"
+        )
+        parser.add_argument(
+            "--mapping_data",
+            action = "store",
+            nargs = "+",
+            dest = "mapping_data",
+            help = """Two possibilities can be passed in this argument. First, a list of file names of csvs 
+            that contain mapping data in same order as the --manuscripts argument. Second, a list
+            containing mapping data in the same order as the --manuscripts argument. Each item in the list
+            is a list of dictionaries with keys "folio" and "uri." The latter option is most 
+            useful when calling from the call_command function, rather than the command line."""
+        )
         parser.add_argument(
             "--no-refresh",
             action="store_false",
@@ -23,58 +36,51 @@ class Command(BaseCommand):
             default=True,
             help="Do not refresh Solr after the import",
         )
-
-    help = (
-        "Usage: ./manage.py import_folio_mapping <manuscript_id> <mapping_csv_file> [<manuscript2_id> <mapping_csv_file2> ...]"
-        '\n\tNote that csv files must be in the folder "data_dumps/folio_mapping/"'
-    )
+        parser.add_argument(
+            "--path",
+            action = "store",
+            dest = "csvs_path",
+            default = "data_dumps/folio_mapping",
+            help = "Directory where mapping_csvs are found. Defaults to ./data_dumps/folio_mapping"
+        )
 
     def handle(self, *args, **options):
+        
+        manuscript_ids = options['manuscript_ids']
+        manuscript_mapping_dict = dict(zip(manuscript_ids, options['mapping_data']))
 
-        if len(args) == 0 or len(args) % 2 == 1:
-            self.stdout.write(self.help)
-            return
+        for manuscript_id in manuscript_ids:
+            input_data = manuscript_mapping_dict[manuscript_id]
 
-        manuscripts = []
-
-        for index, arg in enumerate(args):
-            if index % 2 == 0:
-                temp_manuscript = {"id": arg}
-            else:
-                temp_manuscript["file"] = arg
-                manuscripts.append(temp_manuscript)
-
-        for manuscript in manuscripts:
-            manuscript_id = manuscript["id"]
-            input_file = manuscript["file"]
-
+            # Query database for manuscript id.
             try:
                 manuscript = Manuscript.objects.get(id=manuscript_id)
             except IOError:
                 raise IOError(
-                    "Manuscript {0} does not exist".format(manuscript_id)
+                    f"Manuscript {manuscript_id} does not exist"
                 )
-
-            try:
-                mapping_csv = csv.DictReader(
-                    open(
-                        "data_dumps/folio_mapping/{0}".format(input_file), "rU"
+            
+            # If input_data is a string, it should be a csv file name
+            # where mapping data is persisted. Attempt to read it.
+            # If input_data is a list, it should be the mapping data itself.
+            if isinstance(input_data, str):
+                try:
+                    mapping_data = csv.DictReader(
+                        open(
+                            f"{options['csvs_path']}/{input_data}", "rU"
+                        )
                     )
-                )
-            except IOError:
-                raise IOError(
-                    "File data_dumps/folio_mapping/{0} does not exist".format(
-                        input_file
+                except IOError:
+                    raise IOError(
+                        f"File {options['csvs_path']}/{input_data} does not exist"
                     )
-                )
+            elif isinstance(input_data, list):
+                mapping_data = input_data
 
-            self.stdout.write(
-                "Starting import process for manuscript {0}".format(
-                    manuscript_id
-                )
-            )
+            self.stdout.write(f"Starting import process for manuscript {manuscript_id}")
 
-            for index, row in enumerate(mapping_csv):
+            # Iterate through rows in the mapping_data.
+            for index, row in enumerate(mapping_data):
                 folio = row["folio"]
                 uri = row["uri"]
 
@@ -93,22 +99,26 @@ class Command(BaseCommand):
                 folio_obj.save()
 
                 if index > 0 and index % 50 == 0:
-                    self.stdout.write("Imported {0} folios".format(index))
+                    self.stdout.write(f"Imported {index} folios")
+
+            manuscript.is_mapped = True
+            manuscript.save()
 
             self.stdout.write(
-                "All folios of manuscript {0} have been imported".format(
-                    manuscript_id
-                )
+                f"All folios of manuscript {manuscript_id} have been imported"
             )
 
         # Refreshing Solr chants is necessary since chants have a field image_uri
-        # which is used when clicking on a search result
+        # which is used when clicking on a search result. Folio records in solr
+        # are already updated during the database saving process through the solr_sync
+        # signal, but chant records are not because no interaction occurs with the chant 
+        # object in the database.
         if options["refresh"]:
             self.stdout.write("Refreshing Solr chants after folio import")
             call_command(
                 "refresh_solr",
-                "chants",
-                *[str(man["id"]) for man in manuscripts]
+                record_type = "chants",
+                manuscript_ids = manuscript_ids
             )
         else:
             self.stdout.write(

--- a/public/cantusdata/management/commands/refresh_solr.py
+++ b/public/cantusdata/management/commands/refresh_solr.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from optparse import make_option
 from cantusdata.models.chant import Chant
 from cantusdata.models.manuscript import Manuscript
 from cantusdata.models.folio import Folio
@@ -16,19 +15,29 @@ class Command(BaseCommand):
     }
 
     help = (
-        "Usage: ./manage.py refresh_solr {{{0}}} [manuscript_id ...]"
-        "\n\tSpecify manuscript ID(s) to only refresh selected items in that/those manuscript(s)"
-        "\n\tUse --all to refresh all {1} types.".format(
-            "|".join(list(TYPE_MAPPING.keys())), len(TYPE_MAPPING)
-        )
+        f"""Refreshes solr index associated with a specific manuscript for a specific type.
+        \n\t Usage: ./manage.py refresh_solr --record_type {"|".join(list(TYPE_MAPPING.keys()))} [--manuscript_ids manuscript_id ...]
+        \n\t Specify manuscript ID(s) to only refresh selected items in that/those manuscript(s)
+        \n\t Use --all_types to refresh all {len(TYPE_MAPPING)} types."""
     )
 
     def add_arguments(self, parser):
-        # "args" means "compatibility mode" to process arbitrary args
-        parser.add_argument("args", nargs=2)
-
+        parser.add_argument("--record_type",
+        action = "store",
+        nargs=1,
+        choices = ["manuscripts", "chants", "folios"],
+        dest = "record_type",
+        help=f"Type of records to refresh. Choose from {list(self.TYPE_MAPPING.keys())}"
+        )
+        parser.add_argument("--manuscript_ids",
+        action = "store",
+        nargs = "*",
+        default = "all_manuscripts", 
+        dest = "manuscript_ids",
+        help = "Manuscripts for which solr should be refreshed."
+        )
         parser.add_argument(
-            "--all",
+            "--all_types",
             action="store_true",
             dest="all",
             default=False,
@@ -37,62 +46,44 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         solr_conn = solr.SolrConnection(settings.SOLR_SERVER)
-
+        # Parse arguments
+        manuscript_ids = options['manuscript_ids']
         types = []
-        manuscript_ids = None
-
         if options["all"]:
-            types += list(self.TYPE_MAPPING.keys())
-        elif len(args) == 0:
-            self.stdout.write(self.help)
-            return
-        elif len(args) > 0:
-            types.append(args[0])
-
-        if len(args) > 1:
-            manuscript_ids = args[1:]
-
-        for type in types:
+            record_types += list(self.TYPE_MAPPING.keys())
+        else:
+            record_types = [options['record_type']]
+            
+        for record_type in record_types:
             # Remove the trailing 's' to make the type singular
-            type_singular = type.rstrip("s")
-            model = self.TYPE_MAPPING[type]
+            type_singular = record_type.rstrip("s")
+            model = self.TYPE_MAPPING[record_type]
 
-            self.stdout.write("Flushing {0} data...".format(type_singular))
+            self.stdout.write(f"Flushing {type_singular} data...")
 
-            if manuscript_ids:
+            if manuscript_ids == "all_manuscripts":
+                # Create delete query for all manuscripts
+                delete_query = f"type:cantusdata_{type_singular}"
+            else:
+                # Create delete query for some manuscripts if specific manuscripts are specified.
+                # Create string of the form: "( MAN_ID1 OR MAN_ID2 OR ... )"
                 formatted_ids = "(" + " OR ".join(manuscript_ids) + ")"
                 if model == Manuscript:
-                    delete_query = (
-                        "type:cantusdata_{0} AND item_id:{1}".format(
-                            type_singular, formatted_ids
-                        )
-                    )
+                    delete_query = f"type:cantusdata_{type_singualar} AND item_id:{formatted_ids}"
                 else:
-                    delete_query = (
-                        "type:cantusdata_{0} AND manuscript_id:{1}".format(
-                            type_singular, formatted_ids
-                        )
-                    )
-            else:
-                delete_query = "type:cantusdata_{0}".format(type_singular)
+                    delete_query = f"type:cantusdata_{type_singular} AND manuscript_id:{formatted_ids}"
 
             solr_conn.delete_query(delete_query)
 
-            self.stdout.write(
-                "Re-adding {0} data... (may take a few minutes)".format(
-                    type_singular
-                )
-            )
+            self.stdout.write(f"Re-adding {type_singular} data... (may take a few minutes)")
 
-            if not manuscript_ids:
+            if manuscript_ids == "all_manuscripts":
                 objects = model.objects.all()
             else:
                 if model == Manuscript:
                     objects = model.objects.filter(id__in=manuscript_ids)
                 else:
-                    objects = model.objects.filter(
-                        manuscript__id__in=manuscript_ids
-                    )
+                    objects = model.objects.filter(manuscript__id__in=manuscript_ids)
 
             solr_records = []
             nb_obj = len(objects)
@@ -100,8 +91,8 @@ class Command(BaseCommand):
                 solr_records.append(object.create_solr_record())
 
                 # Adding by blocks prevents out of memory errors
-                if index > 0 and index % 500 == 0 or index == nb_obj - 1:
-                    self.stdout.write("{0} / {1}".format(index + 1, nb_obj))
+                if (index > 0 and index % 500 == 0) or (index == nb_obj - 1):
+                    self.stdout.write(f"{index + 1} / {nb_obj}")
                     solr_conn.add_many(solr_records)
                     solr_records = []
 

--- a/public/cantusdata/views/map_folios.py
+++ b/public/cantusdata/views/map_folios.py
@@ -166,7 +166,7 @@ def _remove_number_padding(s):
 
 @transaction.atomic
 def _save_mapping(request):
-    """ Called in case of a POST request to map_folios.
+    """Called in case of a POST request to map_folios.
     Contents of post request should have:
     - a csrfmiddlewaretoken key-value pair
     - a manuscript_id key with the id of mapped manuscript as value
@@ -174,12 +174,12 @@ def _save_mapping(request):
       and values is a folio name
     Creates a temporary csv dump of folio mapping data and
     calls the import_folio_mapping command."""
-    
+
     manuscript_id = request.POST["manuscript_id"]
 
     # Create list of data for writing to CSV
     # with column headers "folio" and "uri"
-    data = [] 
+    data = []
     for index, value in request.POST.items():
         # 'index' should be the uri, and 'value' the folio name
         if (
@@ -188,7 +188,10 @@ def _save_mapping(request):
             or len(value) == 0
         ):
             continue
-        data.append({"folio":value, "uri" : index})
-    
-    call_command("import_folio_mapping", manuscripts = [manuscript_id], mapping_data = [data],
+        data.append({"folio": value, "uri": index})
+
+    call_command(
+        "import_folio_mapping",
+        manuscripts=[manuscript_id],
+        mapping_data=[data],
     )

--- a/public/cantusdata/views/map_folios.py
+++ b/public/cantusdata/views/map_folios.py
@@ -166,13 +166,20 @@ def _remove_number_padding(s):
 
 @transaction.atomic
 def _save_mapping(request):
-    # Add stuff in Solr if POST arguments
-    # A file dump should also be created so that Solr can be refreshed
-
+    """ Called in case of a POST request to map_folios.
+    Contents of post request should have:
+    - a csrfmiddlewaretoken key-value pair
+    - a manuscript_id key with the id of mapped manuscript as value
+    - a series of key-value pairs where key is a IIIF uri
+      and values is a folio name
+    Creates a temporary csv dump of folio mapping data and
+    calls the import_folio_mapping command."""
+    
     manuscript_id = request.POST["manuscript_id"]
-    manuscript = Manuscript.objects.get(id=manuscript_id)
-    data = [["folio", "uri"]]  # CSV column headers
 
+    # Create list of data for writing to CSV
+    # with column headers "folio" and "uri"
+    data = [] 
     for index, value in request.POST.items():
         # 'index' should be the uri, and 'value' the folio name
         if (
@@ -181,31 +188,7 @@ def _save_mapping(request):
             or len(value) == 0
         ):
             continue
-
-        # Save in the Django DB
-        try:
-            folio_obj = Folio.objects.get(number=value, manuscript__id=manuscript_id)
-        except Folio.DoesNotExist:
-            # If no folio is found, create one
-            folio_obj = Folio()
-            folio_obj.number = value
-            folio_obj.manuscript = manuscript
-
-        folio_obj.image_uri = index
-        folio_obj.save()
-
-        # Data to be saved in a CSV file
-        data.append([value, index])
-
-    # Save in a data dump
-    with open(
-        "./data_dumps/folio_mapping/{0}.csv".format(manuscript_id), "w"
-    ) as dump_csv:
-        csv_writer = csv.writer(dump_csv)
-        csv_writer.writerows(data)
-
-    # Refresh all chants in solr after the folios have been updated
-    manuscript.is_mapped = True
-    manuscript.save()
-    call_command("refresh_solr", "chants", str(manuscript_id))
-    call_command("import_folio_mapping", manuscript_id, "{}.csv".format(manuscript_id))
+        data.append({"folio":value, "uri" : index})
+    
+    call_command("import_folio_mapping", manuscripts = [manuscript_id], mapping_data = [data],
+    )

--- a/public/cantusdata/views/map_folios.py
+++ b/public/cantusdata/views/map_folios.py
@@ -177,7 +177,7 @@ def _save_mapping(request):
 
     manuscript_id = request.POST["manuscript_id"]
 
-    # Create list of data for writing to CSV
+    # Create list of data for saving
     # with column headers "folio" and "uri"
     data = []
     for index, value in request.POST.items():


### PR DESCRIPTION
Revises the map follio (found at /admin/map_folio url) procedure by: 
- Removing the intermediate persistence of a csv with mapping data in the file system when folio mapping is completed through the browser.
- Deduplicated the process of saving mapping data to postgres and re-indexing data in solr (now, database interactions and solr reindexing only take place in commands, rather than in both commands AND the map_folio.py view).
- Simplified the structure of the import_folio_mapping and refresh_solr commands.