### PR TITLE
Modifies Solr synch signal to allow for concurrent db transactions

### DIFF
--- a/app/public/cantusdata/signals/solr_sync.py
+++ b/app/public/cantusdata/signals/solr_sync.py
@@ -48,8 +48,9 @@ class SolrSynchronizer(object):
     @contextlib.contextmanager
     def get_session(self):
         if self._session:
-            yield self._session
-            return
+            if not self._session._executing_flag:
+                yield self._session
+                return
 
         self._session = SynchronizationSession(self.solr_server_url)
 
@@ -103,7 +104,9 @@ class SynchronizationSession(object):
         self._deletions = set()
         self._additions = set()
 
+        self._executing_flag = False
     def execute(self):
+        self._executing_flag = True
         conn = solr.SolrConnection(self.solr_server_url)
 
         for deleted in self._deletions:
@@ -113,6 +116,7 @@ class SynchronizationSession(object):
             [added.create_solr_record() for added in self._additions]
         )
         conn.commit()
+        self._executing_flag = False
 
     def schedule_update(self, model, is_new=False):
         if not is_new:


### PR DESCRIPTION
The prior instantiation of the signal would raise a set-related error
when multiple processes were making DB transations. Items would be added
to the SynchronizationSession objects _deletions and _additions attributes
during iteration (ie. when the execute method was called).

Adds an executing flag to the Solr synchronizer so that solr additions
and deletions will not be added to the set during iteration. Instead,
another SynchronizationSession will be created.