### PR TITLE
Docker compose healthcheck

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,11 @@
+# Don't Touch!!
+COMPOSE_PROJECT_NAME=cantus
+
+#Sets the DEBUG Django setting
+#DEBUG = true for staging, DEBUG = false for production
+DEBUG=false 
+
+#Postgres authentication variables
 POSTGRES_DB=cantus_db
 POSTGRES_USER=cantus_admin
 #POSTGRES_PASSWORD=**PROVIDE PASSWORD HERE**

--- a/app/public/cantusdata/settings.py
+++ b/app/public/cantusdata/settings.py
@@ -79,9 +79,9 @@ WSGI_APPLICATION = "cantusdata.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": "cantus_db",
-        "USER": "cantus_admin",
-        "PASSWORD": "Pl4c3H0ld3r",
+        "NAME": os.environ.get("POSTGRES_DB"),
+        "USER": os.environ.get("POSTGRES_USER"),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
         "HOST": "postgres",
         "PORT": "5432",
     }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,10 +2,12 @@ version: '3.7'
 services:
   app:
     build: ./app
-    command: ["/code/wait-for-it.sh", "postgres:5432", "--", "/code/django-config.sh"]
+    command: /code/django-config.sh
     depends_on:
-      - postgres
-      - solr
+      postgres:
+        condition: service_healthy
+      solr:
+        condition: service_started
     environment:
       - DEBUG=${DEBUG}
       - POSTGRES_DB=${POSTGRES_DB}
@@ -21,6 +23,12 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    healthcheck:
+      test: "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"
+      interval: 30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
 
   nginx:
     build: ./nginx

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,10 @@ services:
       - solr
     environment:
       - DEBUG=${DEBUG}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+
 
   postgres:
     build: ./postgres


### PR DESCRIPTION
Changes to docker-compose.yaml mean that build of the app container
will wait until the postgres container has status "healthy". Postgres
container is determined healthy when pg_isready, the Postgres command
that tests whether server is accepting connections, returns a positive
result.