### PR TITLE
Add healthcheck on postgres container to docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,10 +2,12 @@ version: '3.7'
 services:
   app:
     build: ./app
-    command: ["/code/wait-for-it.sh", "postgres:5432", "--", "/code/django-config.sh"]
+    command: /code/django-config.sh
     depends_on:
-      - postgres
-      - solr
+      postgres:
+        condition: service_healthy
+      solr:
+        condition: service_started
     environment:
       - DEBUG=${DEBUG}
       - POSTGRES_DB=${POSTGRES_DB}
@@ -21,6 +23,12 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    healthcheck:
+      test: "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"
+      interval: 30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
 
   nginx:
     build: ./nginx


### PR DESCRIPTION
Changes to docker-compose.yaml mean that build of the app container
will wait until the postgres container has status "healthy". Postgres
container is determined healthy when pg_isready, the Postgres command
that tests whether server is accepting connections, returns a positive
result.