### PR TITLE
Upgrade to Django 4

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.6.9
+FROM python:3.10.4
 COPY . /code/
 EXPOSE 8001
 

--- a/app/django-config.sh
+++ b/app/django-config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 python manage.py makemigrations
-python manage.py migrate
+python manage.py migrate &
 
 gunicorn -b 0:8001 cantusdata.wsgi --timeout 600 --workers 4

--- a/app/public/cantusdata/admin/admin.py
+++ b/app/public/cantusdata/admin/admin.py
@@ -52,7 +52,7 @@ class ManuscriptAdmin(admin.ModelAdmin):
 
     def load_chants(self, request, queryset):
         for manuscript in queryset:
-            call_command("import_data", "chants", manuscript_id=manuscript.pk)
+            call_command("import_data", "chants", f"--manuscript-id={manuscript.pk}")
         self.message_user(request, "Loaded chants for manuscript")
 
     load_chants.short_description = "Imports the chants associated \

--- a/app/public/cantusdata/urls.py
+++ b/app/public/cantusdata/urls.py
@@ -22,7 +22,8 @@ from cantusdata.views import staticpages
 from django.contrib.admin.views.decorators import staff_member_required
 
 urlpatterns = [
-    # Admin pages
+    # Admin pages - add any additional custom view directs above the 
+    # catch-all admin.site.urls.
     path(
         "admin/map_folios/",
         staff_member_required(MapFoliosView.as_view()),

--- a/app/public/requirements.txt
+++ b/app/public/requirements.txt
@@ -1,9 +1,9 @@
-Django==3.2
-django-extensions==3.1.0
-djangorestframework==3.12.2
+Django==4.0.4
+django-extensions==3.1.5
+djangorestframework==3.13.1
 gunicorn==20.1.0
-Markdown==2.6.2
-psycopg2==2.8.6
-requests==2.20.0
-solrpy==0.9.9
-coverage==4.0.3
+Markdown==3.3.7
+psycopg2==2.9.3
+requests==2.27.1
+solrpy==1.0.0
+coverage==6.4


### PR DESCRIPTION
- Upgrades to Django 4
- Upgrades to python10 in app container to support Django 4
- Runs `python manage.py migrate` in background during app build so site is available when existing data is indexed by solr.