### PR TITLE
Removing reference to `wait-for-it` in `app/Dockerfile`

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,7 +4,6 @@ COPY . /code/
 EXPOSE 8001
 
 RUN chmod u+x /code/django-config.sh
-RUN chmod u+x /code/wait-for-it.sh
 
 RUN echo $(tr -dc A-Za-z0-9 </dev/urandom | head -c 64) >> /etc/key.txt
 


### PR DESCRIPTION
forgot to take out the reference to wait-for-it from the app Dockerfile