### PR TITLE
Run initial migrate command in background.

### DIFF
--- a/app/django-config.sh
+++ b/app/django-config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 python manage.py makemigrations
-python manage.py migrate
+python manage.py migrate &
 
 gunicorn -b 0:8001 cantusdata.wsgi --timeout 600 --workers 4


### PR DESCRIPTION
Running the migrate command results in a complete reindexing of the
Solr backend. Running in background allows access to website while
indexing is completed.