### PR TITLE
Matching django versions in requirements

### DIFF
--- a/nginx/public/python/requirements.txt
+++ b/nginx/public/python/requirements.txt
@@ -1,2 +1,2 @@
-Django==3.1.6
+Django==3.2.13
 psycopg2==2.8.6


### PR DESCRIPTION
Matching django versions in `app/public/requirements.txt` and `nginx/public/python/requirements.txt`