### PR TITLE
Add intermediate page after import chant action

### DIFF
--- a/app/public/cantusdata/admin/admin.py
+++ b/app/public/cantusdata/admin/admin.py
@@ -6,6 +6,7 @@ from cantusdata.models.folio import Folio
 from cantusdata.models.plugin import Plugin
 from cantusdata.models.neume_exemplar import NeumeExemplar
 from django.core.management import call_command
+from django.http import HttpResponseRedirect
 
 
 def reindex_in_solr(modeladmin, request, queryset):
@@ -50,13 +51,13 @@ class ManuscriptAdmin(admin.ModelAdmin):
     )
     list_display = ("name", "siglum", "public", "chants_loaded", "is_mapped")
 
+    @admin.action(description = "Imports the chants associated \
+        with the selected manuscript(s)")
     def load_chants(self, request, queryset):
-        for manuscript in queryset:
-            call_command("import_data", "chants", f"--manuscript-id={manuscript.pk}")
+        manuscript_ids = [str(manuscript.pk) for manuscript in queryset]
+        manuscript_ids_str = ','.join(manuscript_ids)
         self.message_user(request, "Loaded chants for manuscript")
-
-    load_chants.short_description = "Imports the chants associated \
-        with the selected manuscript(s)"
+        return HttpResponseRedirect(f'/admin/cantusdata/manuscript/load_chants/?manuscript_ids={manuscript_ids_str}')
 
 
 class ChantAdmin(admin.ModelAdmin):

--- a/app/public/cantusdata/templates/admin/load_chants.html
+++ b/app/public/cantusdata/templates/admin/load_chants.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block head %}
+<style>
+    h2, h5 {
+        width: 100%;
+        text-align: center;
+    }
+
+    .blue-button {
+        background-color: #264cff;
+        color: white;
+        border: solid 1px #0b97c4;
+        padding: 7px;
+        text-align: center;
+        display: inline-block;
+        cursor: pointer;
+    }
+
+    .horizontal-center {
+  margin: 0;
+  position: absolute;
+  left: 50%;
+    }
+</style>
+{% endblock %}
+{% block body %}
+<h2>Chants are being loaded for these manuscripts.</h2>
+<h5>The changes are currently being applied to the database. They should appear in a few minutes.</h5>
+<form action="/admin/cantusdata/manuscript/">
+    <input class="blue-button horizontal-center" type="submit" value="Return to Admin Page">
+</form>
+{% endblock %}

--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -154,7 +154,7 @@
         {% endfor %}
     </ul>
     <div class="final-submit">
-        <input class="blue-button" type="submit" value="Submit this Mapping">
+        <input class="blue-button" type="button" value="Submit this Mapping">
     </div>
 </form>
 <div class="backup-options">

--- a/app/public/cantusdata/urls.py
+++ b/app/public/cantusdata/urls.py
@@ -17,6 +17,7 @@ from cantusdata.views.chant_set import (
 from cantusdata.views.folio_set import ManuscriptFolioSetView
 from cantusdata.views.manuscript_glyph_set import ManuscriptGlyphSetView
 from cantusdata.views.map_folios import MapFoliosView
+from cantusdata.views.load_chants import LoadChantsView
 from cantusdata.views.manifest_proxy import ManifestProxyView
 from cantusdata.views import staticpages
 from django.contrib.admin.views.decorators import staff_member_required
@@ -29,6 +30,10 @@ urlpatterns = [
         "admin/map_folios/",
         staff_member_required(MapFoliosView.as_view()),
         name="map-folios-view",
+    ),
+    path("admin/cantusdata/manuscript/load_chants/",
+        staff_member_required(LoadChantsView.as_view()),
+        name="load-chants-view",
     ),
     path("admin/", admin.site.urls),
     # Static pages

--- a/app/public/cantusdata/views/load_chants.py
+++ b/app/public/cantusdata/views/load_chants.py
@@ -1,0 +1,21 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.renderers import TemplateHTMLRenderer
+from django.core.management import call_command
+import threading
+
+
+class LoadChantsView(APIView):
+    template_name = "admin/load_chants.html"
+    renderer_classes = (TemplateHTMLRenderer,)
+
+    def get(self, request):
+        manuscript_ids = request.GET['manuscript_ids'].split(',')
+        try:
+            for man_id in manuscript_ids:
+                thread = threading.Thread(target=call_command, args=("import_data", "chants",f"--manuscript-id={man_id}"), kwargs={})
+                thread.start()
+        except Exception as e:
+            return Response({"error": e})
+
+        return Response({'manuscript_ids':manuscript_ids})

--- a/app/public/cantusdata/views/load_chants.py
+++ b/app/public/cantusdata/views/load_chants.py
@@ -10,12 +10,20 @@ class LoadChantsView(APIView):
     renderer_classes = (TemplateHTMLRenderer,)
 
     def get(self, request):
-        manuscript_ids = request.GET['manuscript_ids'].split(',')
+        manuscript_ids = request.GET["manuscript_ids"].split(",")
         try:
             for man_id in manuscript_ids:
-                thread = threading.Thread(target=call_command, args=("import_data", "chants",f"--manuscript-id={man_id}"), kwargs={})
+                thread = threading.Thread(
+                    target=call_command,
+                    args=(
+                        "import_data",
+                        "chants",
+                        f"--manuscript-id={man_id}",
+                    ),
+                    kwargs={},
+                )
                 thread.start()
         except Exception as e:
             return Response({"error": e})
 
-        return Response({'manuscript_ids':manuscript_ids})
+        return Response({"manuscript_ids": manuscript_ids})


### PR DESCRIPTION
Allows for the bulk of the import chant command to complete
on a thread in the background called from the new intermediate
page view. Solves issue of import chant action timeout in
admin page.

Intermediate solve for #150 