### PR TITLE
Fixes a django error when saving changes to manuscript objects

### DIFF
--- a/app/public/cantusdata/models/manuscript.py
+++ b/app/public/cantusdata/models/manuscript.py
@@ -43,7 +43,7 @@ class Manuscript(models.Model):
             force_insert, force_update, *args, **kwargs
         )
 
-        if self.public != self._last_public_value:
+        if (self.public != self._last_public_value) and self.chants_loaded:
             # The public property has changed, we need to refresh the Solr chants
             thread = threading.Thread(
                 target=call_command,

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -23,7 +23,7 @@ class MapFoliosView(APIView):
         # display list of manuscripts and mapping status.
         if "manuscript_id" not in request.GET:
             manuscripts = Manuscript.objects.filter(
-                manifest_url__isnull=False, public=True
+                manifest_url__isnull=False, public=True, chants_loaded=True
             )
             manuscript_ids = [(m.id, str(m), m.is_mapped) for m in manuscripts]
 


### PR DESCRIPTION
The manuscript model's save method was re-indexing chants in solr
even if chants had never been loaded. Although the error had no
impact on performance, the error is now avoided.