### PR TITLE
Add command for clearing django session data

### DIFF
--- a/app/django-config.sh
+++ b/app/django-config.sh
@@ -2,5 +2,6 @@
 
 python manage.py makemigrations
 python manage.py migrate &
+python manage.py clear_session_data
 
 gunicorn -b 0:8001 cantusdata.wsgi --timeout 600 --workers 4

--- a/app/public/cantusdata/management/commands/clear_session_data.py
+++ b/app/public/cantusdata/management/commands/clear_session_data.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.db import connection
+
+class Command(BaseCommand):
+    """
+    Completely clears the django_session table. Runs `TRUNCATE django_session` against the
+    databse. 
+
+    This is useful when building the app container with a database that is not a fresh build
+    to avoid a 'Session data corrupted' warning.
+    """
+    def handle(self, *args, **options):
+        with connection.cursor() as cursor:
+            cursor.execute("TRUNCATE django_session;")


### PR DESCRIPTION
Persisting session data between builds of the site causes a "Session
data corrupted" warning to be thrown. At app build, session data is
now cleared using the new clear_session_data command.