### PR TITLE
Add --check parameter to black github action

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -8,8 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
-        with: 
-          options: ""
   run-tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The Black github action should now check the formatting status of pull requests and fail if files are not linted.