### PR TITLE
Changes build source for celery container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
     restart: always
 
   celery:
-    image:  cantus_app
+    build:  ./app
     container_name: cantus-celery-1
     command: ["celery", "-A", "cantusdata", "worker", "-l", "INFO", "-c", "1"]
     environment:


### PR DESCRIPTION
Previous docker compose depended on app image being built first.
Now, build order does not matter.