### PR TITLE
Update README to include initial docker compose build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Execute the following commands from the root directory of the repo:
 
 ```sh
 # Build the images and launch the containers (this will take a while)
+$ docker-compose build
 $ docker-compose up -d
 ```
 


### PR DESCRIPTION
This is required because the celery container depends on the image
build for the app service. Running the docker compose up command
initially will try to pull the app container from a remote repo,
rather than build it locally.