### PR TITLE
Add PENDING state to manuscript mapping

### DIFF
--- a/app/public/cantusdata/fixtures/2_initial_data.json
+++ b/app/public/cantusdata/fixtures/2_initial_data.json
@@ -6,7 +6,8 @@
         "provenance": "provigo",
         "date": "tomorrow",
         "description": "A very nice manuscript...",
-        "public": true
+        "public": true,
+        "is_mapped":"MAPPED"
       },
       "model": "cantusdata.manuscript",
       "pk": 1
@@ -18,7 +19,8 @@
         "provenance": "",
         "date": "",
         "description": "",
-        "public": false
+        "public": false,
+        "is_mapped":"PENDING"
       },
       "model": "cantusdata.manuscript",
       "pk": 2
@@ -29,7 +31,8 @@
         "name": "geoff",
         "provenance": "",
         "date": "",
-        "description": ""
+        "description": "",
+        "is_mapped":"UNMAPPED"
       },
       "model": "cantusdata.manuscript",
       "pk": 3

--- a/app/public/cantusdata/management/commands/import_data.py
+++ b/app/public/cantusdata/management/commands/import_data.py
@@ -95,6 +95,7 @@ class Command(BaseCommand):
             manuscript.date = date
             manuscript.provenance = provenance
             manuscript.description = description
+            manuscript.is_mapped = "UNMAPPED"
             manuscript.save()
             i += 1
         self.stdout.write(

--- a/app/public/cantusdata/management/commands/import_folio_mapping.py
+++ b/app/public/cantusdata/management/commands/import_folio_mapping.py
@@ -130,5 +130,5 @@ class Command(BaseCommand):
             )
         for manuscript_id in manuscript_ids:
             manuscript = Manuscript.objects.get(id=manuscript_id)
-            manuscript.is_mapped = 'MAPPED'
+            manuscript.is_mapped = "MAPPED"
             manuscript.save()

--- a/app/public/cantusdata/management/commands/import_folio_mapping.py
+++ b/app/public/cantusdata/management/commands/import_folio_mapping.py
@@ -107,7 +107,6 @@ class Command(BaseCommand):
                 if index > 0 and index % 50 == 0:
                     self.stdout.write(f"Imported {index} folios")
 
-            manuscript.is_mapped = True
             manuscript.save()
 
             self.stdout.write(
@@ -129,3 +128,7 @@ class Command(BaseCommand):
                 "Import process completed. To refresh Solr,"
                 "use './manage.py refresh_solr chants [manuscript_id ...]'"
             )
+        for manuscript_id in manuscript_ids:
+            manuscript = Manuscript.objects.get(id=manuscript_id)
+            manuscript.is_mapped = 'MAPPED'
+            manuscript.save()

--- a/app/public/cantusdata/models/manuscript.py
+++ b/app/public/cantusdata/models/manuscript.py
@@ -5,7 +5,11 @@ import threading
 
 from cantusdata.models.neume_exemplar import NeumeExemplar
 
-
+class IsMapped(models.TextChoices):
+    UNMAPPED = "UNMAPPED", "Unmapped"
+    PENDING = "PENDING", "Pending"
+    MAPPED = "MAPPED", "Mapped"
+    
 class Manuscript(models.Model):
     """The top-level model, representing a particular manuscript
 
@@ -16,6 +20,7 @@ class Manuscript(models.Model):
     class Meta:
         app_label = "cantusdata"
         ordering = ["name"]
+        constraints = [models.CheckConstraint(check = models.Q(is_mapped__in = IsMapped.values), name = "is_mapped_status")]
 
     name = models.CharField(max_length=255, blank=True, null=True)
     siglum = models.CharField(max_length=255, blank=True, null=True)
@@ -23,7 +28,7 @@ class Manuscript(models.Model):
     provenance = models.CharField(max_length=100, blank=True, null=True)
     description = models.TextField(blank=True, null=True)
     public = models.BooleanField(default=False)
-    is_mapped = models.BooleanField(default=False)
+    is_mapped = models.CharField(max_length=10, choices=IsMapped.choices)
     chants_loaded = models.BooleanField(default=False)
     plugins = models.ManyToManyField(
         "cantusdata.Plugin", related_name="plugins", blank=True

--- a/app/public/cantusdata/models/manuscript.py
+++ b/app/public/cantusdata/models/manuscript.py
@@ -5,11 +5,13 @@ import threading
 
 from cantusdata.models.neume_exemplar import NeumeExemplar
 
+
 class IsMapped(models.TextChoices):
     UNMAPPED = "UNMAPPED", "Unmapped"
     PENDING = "PENDING", "Pending"
     MAPPED = "MAPPED", "Mapped"
-    
+
+
 class Manuscript(models.Model):
     """The top-level model, representing a particular manuscript
 
@@ -20,7 +22,11 @@ class Manuscript(models.Model):
     class Meta:
         app_label = "cantusdata"
         ordering = ["name"]
-        constraints = [models.CheckConstraint(check = models.Q(is_mapped__in = IsMapped.values), name = "is_mapped_status")]
+        constraints = [
+            models.CheckConstraint(
+                check=models.Q(is_mapped__in=IsMapped.values), name="is_mapped_status"
+            )
+        ]
 
     name = models.CharField(max_length=255, blank=True, null=True)
     siglum = models.CharField(max_length=255, blank=True, null=True)

--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -80,6 +80,10 @@
         color: green;
     }
 
+    .folio-pending {
+        color: goldenrod;
+    }
+
     .folio-unmapped {
         color: red;
     }
@@ -114,14 +118,18 @@
     {% for m_id, m_str, is_mapped in manuscript_ids %}
     <tr>
         <td>{{ m_str }}</td>
-            {% if is_mapped %}
+            {% if is_mapped == "MAPPED" %}
             <td class="folio-mapped">Already mapped</td>
+            {% elif is_mapped == "PENDING" %}
+            <td class="folio-pending">Map pending</td>
             {% else %}
             <td class="folio-unmapped">Not mapped</td>
             {% endif %}
         <td>
-            {% if is_mapped %}
+            {% if is_mapped == "MAPPED" %}
             <a href="/admin/map_folios/?manuscript_id={{ m_id }}" class="table-link">Edit map</a>
+            {% elif is_mapped == "PENDING" %}
+            <span>Wait for mapping to process</span>
             {% else %}
             <a href="/admin/map_folios/?manuscript_id={{ m_id }}" class="table-link">Map now</a>
             {% endif %}

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -177,10 +177,10 @@ def _save_mapping(request):
     calls the import_folio_mapping command."""
 
     manuscript_id = request.POST["manuscript_id"]
-    manuscript = Manuscript.objects.get(id = manuscript_id)
+    manuscript = Manuscript.objects.get(id=manuscript_id)
     manuscript.is_mapped = "PENDING"
     manuscript.save()
-    
+
     # Create list of data for saving
     # with column headers "folio" and "uri"
     data = []

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -74,7 +74,7 @@ class MapFoliosView(APIView):
             folios.append(folio.number)
             if folio.image_link:
                 folio_imagelink[folio.number] = folio.image_link
-            if man_is_mapped:
+            if man_is_mapped == "MAPPED":
                 uri_folio_map[folio.image_uri] = folio.number
 
         imagelinks = list(folio_imagelink.values())
@@ -85,7 +85,7 @@ class MapFoliosView(APIView):
         for idx, uri in enumerate(uris_objs):
             uri["id"] = uri_ids[idx]
             uri["folio"] = None
-            if man_is_mapped:
+            if man_is_mapped == "MAPPED":
                 uri["folio"] = uri_folio_map.get(uri["full"], "")
                 mapped_folios += 1
             else:
@@ -177,7 +177,10 @@ def _save_mapping(request):
     calls the import_folio_mapping command."""
 
     manuscript_id = request.POST["manuscript_id"]
-
+    manuscript = Manuscript.objects.get(id = manuscript_id)
+    manuscript.is_mapped = "PENDING"
+    manuscript.save()
+    
     # Create list of data for saving
     # with column headers "folio" and "uri"
     data = []


### PR DESCRIPTION
Adds a PENDING state to the manuscript model for is_mapped,
away from a binary state. This allows for the manuscript mapped
status to show as this interim state while processing on manuscript mapping
completes. This interim status shows on the admin/map_folios page
and the admin view during this time.