### PR TITLE
Make manuscripts link in navbar more prominent

### DIFF
--- a/app/public/cantusdata/templates/base.html
+++ b/app/public/cantusdata/templates/base.html
@@ -46,11 +46,11 @@
                     </div>
                     <div class="collapse navbar-collapse" id="top-menu">
                         <ul class="nav navbar-nav navbar-right">
+                            <li><a style="font-weight:bold; font-size:larger" href="/manuscripts/">Manuscripts</a></li>
                             <li><a href="/manifests/">IIIF Manifests</a></li>
                             <li><a href="/about/">About</a></li>
                             <li><a href="/activities/">Activities</a></li>
                             <li><a href="/team/">Team</a></li>
-                            <li><a href="/manuscripts/">Manuscripts</a></li>
                             <li><a href="/search/" class="search-modal-link">Search</a></li>
                         </ul>
                     </div>


### PR DESCRIPTION
Makes the manuscripts link in the header navbar more prominent
by bolding text, making text bigger, and moving the to first link
in the list.