### PR TITLE
Update map folios and chant import processes

### DIFF
--- a/app/public/cantusdata/admin/admin.py
+++ b/app/public/cantusdata/admin/admin.py
@@ -57,9 +57,8 @@ class ManuscriptAdmin(admin.ModelAdmin):
         with the selected manuscript(s)"
     )
     def load_chants(self, request, queryset):
-        manuscript_ids = [manuscript.pk for manuscript in queryset]
-        for manuscript in manuscript_ids:
-            chant_import_task.apply_async(kwargs={"manuscript_ids": [manuscript]})
+        for ms in queryset:
+            chant_import_task.apply_async(kwargs={"manuscript_ids": [ms.pk]})
         self.message_user(
             request,
             "Importing chants for the selected manuscripts. This may take a few minutes. Check status on the Task Results page.",

--- a/app/public/cantusdata/admin/admin.py
+++ b/app/public/cantusdata/admin/admin.py
@@ -59,13 +59,11 @@ class ManuscriptAdmin(admin.ModelAdmin):
     def load_chants(self, request, queryset):
         manuscript_ids = [manuscript.pk for manuscript in queryset]
         for manuscript in manuscript_ids:
-            chant_import_task.apply_async(
-                kwargs={"manuscript_ids": [manuscript]}
-            )
-        self.message_user(request,
-            "Importing chants for the selected manuscripts. This may take a few minutes. Check status on the Task Results page."
+            chant_import_task.apply_async(kwargs={"manuscript_ids": [manuscript]})
+        self.message_user(
+            request,
+            "Importing chants for the selected manuscripts. This may take a few minutes. Check status on the Task Results page.",
         )
-
 
 
 class ChantAdmin(admin.ModelAdmin):

--- a/app/public/cantusdata/admin/admin.py
+++ b/app/public/cantusdata/admin/admin.py
@@ -58,12 +58,14 @@ class ManuscriptAdmin(admin.ModelAdmin):
     )
     def load_chants(self, request, queryset):
         manuscript_ids = [manuscript.pk for manuscript in queryset]
-        chant_import_result = chant_import_task.apply_async(
-            kwargs={"manuscript_ids": manuscript_ids}
+        for manuscript in manuscript_ids:
+            chant_import_task.apply_async(
+                kwargs={"manuscript_ids": [manuscript]}
+            )
+        self.message_user(request,
+            "Importing chants for the selected manuscripts. This may take a few minutes. Check status on the Task Results page."
         )
-        return HttpResponseRedirect(
-            f"/admin/cantusdata/manuscript/load_chants/?id={chant_import_result}"
-        )
+
 
 
 class ChantAdmin(admin.ModelAdmin):

--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -69,6 +69,16 @@
         cursor: pointer;
     }
 
+    .grey-button {
+        background-color: grey;
+        color: white;
+        border: solid 1px #0b97c4;
+        padding: 7px;
+        text-align: center;
+        display: inline-block;
+        cursor: pointer;
+    }
+
     .backup-options {
         position: fixed;
         top: calc(50% + 75px);
@@ -134,7 +144,7 @@
     {% endfor %}
 </table>
 
-{% elif manuscript_id and uris and folios %}
+{% elif manuscript_id and uris and folios and manuscript_mapping_state %}
 
 <h5><br><em>Tip: Use 'Tab' and 'Shift+Tab' to navigate the input fields.</em></h5>
 
@@ -157,9 +167,15 @@
         </li>
         {% endfor %}
     </ul>
+    {% if manuscript_mapping_state == "PENDING" %}
+    <div class="final-submit">
+        <input class="grey-button" type="button" value="Mapping in Progress. Try again later.">
+    </div>
+    {% else %}
     <div class="final-submit">
         <input class="blue-button" type="submit" value="Submit this Mapping">
     </div>
+    {% endif %}
 </form>
 <div class="backup-options">
     <div class="blue-button" onclick="onSaveBackup()">Save Backup</div>

--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -101,11 +101,7 @@
 
 {% block body %}
 
-{% if posted %}
-<h2>The mapping has been successfully saved</h2>
-<h5>The changes are currently being applied to the database. They should appear in a few minutes.</h5>
-
-{% elif error %}
+{% if error %}
 <h2 class="error-message">{{ error }}</h2>
 
 {% elif manuscript_ids %}

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -106,6 +106,7 @@ class MapFoliosView(APIView):
                 "uris": uris_objs,
                 "folios": folios,
                 "manuscript_id": manuscript_id,
+                "manuscript_mapping_state": man_is_mapped,
             }
         )
 

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -6,6 +6,7 @@ from django.db import transaction
 from cantusdata.models.folio import Folio
 from cantusdata.models.manuscript import Manuscript
 from cantusdata.tasks import map_folio_task
+from django.http import HttpResponseRedirect
 import urllib.request, urllib.parse, urllib.error
 import json
 import csv
@@ -115,7 +116,12 @@ class MapFoliosView(APIView):
         except Exception as e:
             return Response({"error": e})
 
-        return Response({"posted": True})
+        manuscript_id = request.POST["manuscript_id"]
+        manuscript = Manuscript.objects.get(id=manuscript_id)
+        manuscript.is_mapped = "PENDING"
+        manuscript.save()
+
+        return HttpResponseRedirect('/admin/map_folios/')
 
 
 def _extract_ids(str_list):
@@ -177,9 +183,6 @@ def _save_mapping(request):
     calls the import_folio_mapping command."""
 
     manuscript_id = request.POST["manuscript_id"]
-    manuscript = Manuscript.objects.get(id=manuscript_id)
-    manuscript.is_mapped = "PENDING"
-    manuscript.save()
 
     # Create list of data for saving
     # with column headers "folio" and "uri"

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -122,7 +122,7 @@ class MapFoliosView(APIView):
         manuscript.is_mapped = "PENDING"
         manuscript.save()
 
-        return HttpResponseRedirect('/admin/map_folios/')
+        return HttpResponseRedirect("/admin/map_folios/")
 
 
 def _extract_ids(str_list):


### PR DESCRIPTION
Includes these updates:

- Create a new task for each manuscript when multiple manuscripts are selected for chat import in the admin view. Older version created a single task with (potentially) multiple manuscripts.
- Remove confirmation page after kicking off chant importing in the admin view. Confirmation is now given with a green banner in the admin view.
- Remove confirmation page after submitting a folio mapping. After #510, mapping shows as pending on the main map folios page. 
- If folio mapping is pending for a manuscript, returning to the map folios page for that manuscript will no longer show a submit button -- shows a pending message instead. This will keep users from manually submitting a duplicate mapping.

These final changes should close #450 & close #473 