### PR TITLE
Fix 500 error in task status admin view

### DIFF
--- a/app/public/cantusdata/admin/admin.py
+++ b/app/public/cantusdata/admin/admin.py
@@ -96,7 +96,12 @@ class NewTaskResultAdmin(TaskResultAdmin):
 
     @admin.display(description="Manuscript(s)")
     def get_task_manuscript_ids(self, obj):
-        obj_man_ids = eval(obj.task_kwargs[1:-1])["manuscript_id"]
+        if obj.status == "RECEIVED":
+            obj_man_ids = eval(obj.task_kwargs)["manuscript_ids"]
+        else:
+            obj_man_ids = eval(obj.task_kwargs[1:-1])["manuscript_ids"]
+        if not isinstance(obj_man_ids, list):
+            obj_man_ids = [obj_man_ids]
         task_manuscripts = [
             man for man in Manuscript.objects.filter(id__in=obj_man_ids)
         ]

--- a/app/public/cantusdata/tasks.py
+++ b/app/public/cantusdata/tasks.py
@@ -20,7 +20,7 @@ def chant_import_task(self, *args, **kwargs):
 def map_folio_task(self, *args, **kwargs):
     call_command(
         "import_folio_mapping",
-        manuscripts=[kwargs["manuscript_id"]],
+        manuscripts=[kwargs["manuscript_ids"]],
         mapping_data=[kwargs["data"]],
         task=self,
     )

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -198,4 +198,4 @@ def _save_mapping(request):
             continue
         data.append({"folio": value, "uri": index})
 
-    map_folio_task.apply_async(kwargs={"manuscript_id": manuscript_id, "data": data})
+    map_folio_task.apply_async(kwargs={"manuscript_ids": manuscript_id, "data": data})


### PR DESCRIPTION
Harmonize argument names in `import_data chants` and `map_folios` task. 
Handle discrepancy in representation of task kwargs in task received status and other task states.