### PR TITLE
Fix wrong manuscript in iiif postprocessing

### DIFF
--- a/app/public/cantusdata/helpers/postprocess_iiif.py
+++ b/app/public/cantusdata/helpers/postprocess_iiif.py
@@ -19,7 +19,7 @@ def d_ka_aug_lx(datadict):
     return datadict
 
 
-def nl_uu_406_3_j_7(datadict):
+def b_gu_hs_bkt_006(datadict):
     """
     Decode encodings from image URLs in the IIIF manifest.
 
@@ -38,5 +38,5 @@ def nl_uu_406_3_j_7(datadict):
 
 iiif_fn = {
     "https://digital.blb-karlsruhe.de/i3f/v20/1253122/manifest": d_ka_aug_lx,
-    "https://adore.ugent.be/IIIF/manifests/archive.ugent.be:082FD364-C35A-11DF-A9D6-99EF78F64438": nl_uu_406_3_j_7,
+    "https://adore.ugent.be/IIIF/manifests/archive.ugent.be:082FD364-C35A-11DF-A9D6-99EF78F64438": b_gu_hs_bkt_006,
 }

--- a/app/public/data_dumps/manifests.csv
+++ b/app/public/data_dumps/manifests.csv
@@ -6,6 +6,7 @@ A-KN 1015,https://manuscripta.at/diglit/iiif/AT5000-1015/manifest.json
 A-KN 1018,https://manuscripta.at/diglit/iiif/AT5000-1018/manifest.json
 A-KN 589,https://manuscripta.at/diglit/iiif/AT5000-589/manifest.json
 B-DEa 9,https://lib.is/IE9129581/manifest
+B-Gu Hs BKT.006,https://adore.ugent.be/IIIF/manifests/archive.ugent.be:082FD364-C35A-11DF-A9D6-99EF78F64438
 CDN-Hsmu M2149.L4,https://lib.is/IE9434868/manifest
 CDN-Mlr MS 073,https://iiif.archivelab.org/iiif/McGillLibrary-rbsc_ms-medieval-073-18802/manifest.json
 CH-E 121,https://www.e-codices.unifr.ch/metadata/iiif/sbe-0121/manifest.json 


### PR DESCRIPTION
Postprocessing for the manuscript Tongerloo, B-Gu Hs BKT.006 was
erroneously attributed to NL-Uu 406 (3 J 7). This is fixed here.