### PR TITLE
Reorder docker builds

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,6 +2,7 @@
 FROM python:3.6.9
 COPY django-config.sh /code/
 COPY public/requirements.txt /code/public/
+COPY cantus-staticpages/ /code/cantus-staticpages/
 EXPOSE 8001
 
 RUN chmod u+x /code/django-config.sh
@@ -10,5 +11,3 @@ RUN echo $(tr -dc A-Za-z0-9 </dev/urandom | head -c 64) >> /etc/key.txt
 
 WORKDIR /code/public
 RUN pip install -r requirements.txt
-
-COPY . /code/

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 FROM python:3.6.9
-COPY . /code/
+COPY django-config.sh /code/
+COPY public/requirements.txt /code/public/
 EXPOSE 8001
 
 RUN chmod u+x /code/django-config.sh
@@ -9,3 +10,5 @@ RUN echo $(tr -dc A-Za-z0-9 </dev/urandom | head -c 64) >> /etc/key.txt
 
 WORKDIR /code/public
 RUN pip install -r requirements.txt
+
+COPY . /code/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,6 +66,8 @@ services:
   celery:
     image: cantus_app
     container_name: cantus-celery-1
+    volumes:
+      - ./app/public:/code/public
     command:
       [
         "runuser",


### PR DESCRIPTION
This slight refactoring of the docker build process makes two adjustments:

1. The `app` image build process is quicker during development and minor code changes, because only (a) critical files for the build process and (b) files that are not otherwise mounted to the container are copied during the build process. Changes to the django codebase do not require an image rebuild.
2. We now mount the django codebase to the `celery` container, rather than relying on it being part of the build. This reduces the possibility that code bases in the `celery` container and `app` container go out of sync. Previously if a change was made to the django codebase and containers were not rebuilt, the update could propagate to the `app` container through the filesystem mount, but would not update in the `celery` container. 