### PR TITLE
Move atomic decorator for async map folios task

### DIFF
--- a/app/public/cantusdata/management/commands/import_folio_mapping.py
+++ b/app/public/cantusdata/management/commands/import_folio_mapping.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 from cantusdata.models.folio import Folio
 from cantusdata.models.manuscript import Manuscript
 from django.core.management import call_command
+from django.db import transaction
 import csv
 
 
@@ -51,6 +52,7 @@ class Command(BaseCommand):
             help="Optional argument used when called from the django admin interface. Passes asynchronous task.",
         )
 
+    @transaction.atomic
     def handle(self, *args, **options):
 
         manuscript_ids = options["manuscript_ids"]

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -1,8 +1,6 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.renderers import TemplateHTMLRenderer
-from django.core.management import call_command
-from django.db import transaction
 from cantusdata.models.folio import Folio
 from cantusdata.models.manuscript import Manuscript
 from cantusdata.tasks import map_folio_task
@@ -172,7 +170,6 @@ def _remove_number_padding(s):
     return ret_str
 
 
-@transaction.atomic
 def _save_mapping(request):
     """Called in case of a POST request to map_folios.
     Contents of post request should have:


### PR DESCRIPTION
Previously, an atomic transaction decorator was used when saving folio mappings in the map folios view to ensure that partially saved folio mappings would be rolled back on failure. 

Now that saving the folio mapping is handled by the celery task queue, the primary database transactions for the map folios process occur in a different function.