### PR TITLE
Fix folio navigation search suggestion peculiarities

### DIFF
--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/DivaView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/DivaView.js
@@ -163,9 +163,10 @@ export default Marionette.ItemView.extend({
     gotoInputPage: function (event)
     {
         event.preventDefault();
-
-        var pageInput = this.toolbarParentObject.find(this.divaInstance.getInstanceSelector() + 'goto-page-input');
-        var pageAlias = pageInput.val();
+        
+        var inputSuggestions = this.toolbarParentObject.find(this.divaInstance.getInstanceSelector() + 'input-suggestions');
+        var pageInput = $('.diva-input-suggestion:first', inputSuggestions)
+        var pageAlias = pageInput.text();
 
         if (!pageAlias)
             return;

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/DivaView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/DivaView.js
@@ -188,7 +188,6 @@ export default Marionette.ItemView.extend({
 
     showPageSuggestions: function showPageSuggestions(event){
         var inputSuggestions = this.toolbarParentObject.find(this.divaInstance.getInstanceSelector() + 'input-suggestions');
-        inputSuggestions.empty();
         var manuscript = manuscriptChannel.request('manuscript');
 
         var pageInput = this.toolbarParentObject.find(this.divaInstance.getInstanceSelector() + 'goto-page-input');
@@ -196,6 +195,7 @@ export default Marionette.ItemView.extend({
         var queryUrl =  '/folio-set/manuscript/' + manuscript + '/?q=' + pageInput.val();
         $.get(queryUrl,
             function (data){
+                inputSuggestions.empty();
                 for (const queryResult of data){
                     var newInputSuggestion = document.createElement('div');
                     newInputSuggestion.setAttribute('class','diva-input-suggestion');


### PR DESCRIPTION
Two folio navigation search suggestion issues detailed #546:

- Clears previous search suggestions more quickly to end situations where very large numbers of suggestions are shown.
- On submitting, the viewer will navigate to the top search suggestion, rather than the current value of the input box.

Closes #546, with residual search suggestion issues in #564. 
