### PR TITLE
Fix broken IIIF manifests in data_dumps/manifests.csv

### DIFF
--- a/app/public/data_dumps/manifests.csv
+++ b/app/public/data_dumps/manifests.csv
@@ -24,8 +24,8 @@ D-Mbs Clm 4303,https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb000601
 D-Mbs Clm 4304,https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00060183/manifest
 D-Mbs Clm 4305,https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00060192/manifest
 D-Mbs Clm 4306,https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00060191/manifest
-D-W 28 Helmst.,https://hab.bodleian.ox.ac.uk/en/image-viewer/?manifest=https://iiif.hab.de/object/mss_28-helmst/manifest 
-D-W 29 Helmst.,https://hab.bodleian.ox.ac.uk/en/image-viewer/?manifest=https://iiif.hab.de/object/mss_29-helmst/manifest
+D-W 28 Helmst.,https://iiif.hab.de/object/mss_28-helmst/manifest 
+D-W 29 Helmst.,https://iiif.hab.de/object/mss_29-helmst/manifest
 D-WI1 2,http://tudigit.ulb.tu-darmstadt.de/show/iiif/Hild_R_Riesencodex/manifest.json
 F-AS 893,https://bvmm.irht.cnrs.fr/iiif/24878/manifest
 F-Pnm lat. 1085,https://gallica.bnf.fr/iiif/ark:/12148/btv1b100389982/manifest.json?iiif-content=https://gallica.bnf.fr/iiif/ark:/12148/btv1b100389982/manifest.json 

--- a/app/public/data_dumps/manifests.csv
+++ b/app/public/data_dumps/manifests.csv
@@ -18,7 +18,7 @@ CH-SGs 359,https://www.e-codices.unifr.ch/metadata/iiif/csg-0359/manifest.json
 CH-SGs 388,https://www.e-codices.unifr.ch/metadata/iiif/csg-0388/manifest.json
 CH-SGs 390,http://www.e-codices.unifr.ch/metadata/iiif/csg-0390/manifest.json 
 CH-SGs 391,http://www.e-codices.unifr.ch/metadata/iiif/csg-0391/manifest.json 
-D-FUl Aa 55,https://fuldig.hs-fulda.de/viewer/rest/iiif/manifests/PPN432340890/manifest 
+D-FUl Aa 55,https://fuldig.hs-fulda.de/viewer/api/v1/records/PPN432340890/manifest/
 D-KA Aug. LX,https://digital.blb-karlsruhe.de/i3f/v20/1253122/manifest
 D-Mbs Clm 4303,https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00060193/manifest
 D-Mbs Clm 4304,https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00060183/manifest


### PR DESCRIPTION
Fixes broken links to IIIF manifests for the following manuscripts:

- D-FUl Aa 55
- D-W 28 Helmst.
- D-W 29 Helmst.