### PR TITLE
Change default ordering in manuscript admin view

### DIFF
--- a/app/public/cantusdata/admin/admin.py
+++ b/app/public/cantusdata/admin/admin.py
@@ -22,6 +22,7 @@ reindex_in_solr.short_description = "ReIndex in Solr"
 
 class ManuscriptAdmin(admin.ModelAdmin):
     actions = [reindex_in_solr, "load_chants"]
+    ordering = ["-public", "name"]
     list_per_page = 200
     fieldsets = [
         (


### PR DESCRIPTION
Default ordering on manuscript admin view is public manuscripts
first, with a secondary ordering by manuscript name.

Closes #576 