### PR TITLE
Fix typo in manifest for US-PRu Princeton MS. 245

### DIFF
--- a/app/public/data_dumps/manifests.csv
+++ b/app/public/data_dumps/manifests.csv
@@ -53,5 +53,5 @@ I-Rvat SP B.79,https://digi.vatlib.it/iiif/MSS_Arch.Cap.S.Pietro.B.79/manifest.j
 MA Impr. 1537,https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00090351/manifest
 PL-WRu I F 401,https://glam.uni.wroc.pl/iiif/RKP_I_F_401_23465/manifest
 US-NYcub Plimpton MS 041,https://dlc.library.columbia.edu/iiif/3/presentation/10.7916/d8-v1my-eg17/manifest
-US-PRu Princeton MS. 245,https://figgy.princeton.edu/concern/scanned_resources/aa41d61e-32d2-4937-95b3-f9452d792ef9/manifest?manifest=https://figgy.princeton.edu/concern/scanned_res ources/aa41d61e-32d2-4937-95b3-f9452d792ef9/manifest 
+US-PRu Princeton MS. 245,https://figgy.princeton.edu/concern/scanned_resources/aa41d61e-32d2-4937-95b3-f9452d792ef9/manifest 
 NL-Uu 406 (3 J 7),https://www.diamm.ac.uk/sources/1355/manifest/


### PR DESCRIPTION
Resolves a typo found by @ahankinson in the IIIF manifests data dump.