### PR TITLE
Change 'no chants' message to refer to chant records

### DIFF
--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantCompositeView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantCompositeView.js
@@ -156,7 +156,7 @@ export default Marionette.CompositeView.extend({
         if (this.collection.length === 0)
         {
             // No chants
-            this.ui.errorMessages.html("No chants begin on this page or folio side.");
+            this.ui.errorMessages.html("No chant records begin on this page or folio side.");
         }
         else
         {


### PR DESCRIPTION
Serves as a quick fix to an issue mentioned in #585 : if there are folios with chants on them that, for whatever reason, do not have records in Cantus DB, it would be more accurate to say that "No chant *records*" begin on a given folio than that "No chants" begin on that folio.