### PR TITLE
Fix CantusDB link where no Cantus ID

### DIFF
--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -163,7 +163,7 @@ export default Marionette.ItemView.extend({
 		var formattedVolpiano = parseVolpianoSyllables(text, volpiano);
 		this.model.set('volpiano', formattedVolpiano);
 		var cdb_uri = this.model.get('cdb_uri');
-		this.model.set({ 'cdb_link_url': 'https://cantus.uwaterloo.ca/chant/' + cdb_uri })
+		this.model.set({ 'cdb_link_url': 'https://cantus.uwaterloo.ca/node/' + cdb_uri })
 	},
 	events: {
 		"click #btnPlay": "submit"

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
@@ -1,5 +1,14 @@
+<% if (cantus_id || cdb_link_url) { %>
+<p>
+<% } %>
 <% if (cantus_id) { %>
-<p><b>Cantus ID:</b> <%= cantus_id %> (<a href = <%= cdb_link_url %> >Visit record in Cantus Database</a>)</p>
+<b>Cantus ID:</b> <%= cantus_id %>
+<% } %>
+<% if (cdb_link_url) { %>
+(<a href = <%= cdb_link_url %> >Visit record in Cantus Database</a>)
+<% } %>
+<% if (cantus_id || cdb_link_url) { %>
+</p>
 <% } %>
 <% if (marginalia) { %>
 <p><b>Marginalia:</b> <%= marginalia %></p>


### PR DESCRIPTION
The previous version of the Chant view template would not include a link to CantusDB if the chant did not have a CantusID. 

The previous link used an unstable URL to CantusDB. We now use `/node/{node_id}` rather than `/chant/{node_id}` to reference a chant record on Cantus DB.