### PR TITLE
Fixes to MIDI playback

### DIFF
--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -100,6 +100,10 @@ function volpiano2midi(input_arr, note_dur) {
 	pitch_dict['R'] = 72;
 	pitch_dict['S'] = 74;
 
+	// create array of volpiano characters representing barlines
+	// for purposes of midi playback, these are treated as rests
+	let rest_arr = ['3','4','5','6'];
+
 	MIDI.loadPlugin({
 		soundfontUrl: "https://cdn.jsdelivr.net/gh/jacobsanz97/test502/soundfont/",
 		instrument: "vowels",
@@ -120,7 +124,10 @@ function volpiano2midi(input_arr, note_dur) {
 					if (pitches.charAt(j) in pitch_dict) {
 						MIDI.noteOn(0, pitch_dict[pitches.charAt(j)], 127, notes_played * note_dur);
 						MIDI.noteOff(0, pitch_dict[pitches.charAt(j)], notes_played * note_dur + note_dur);
-						notes_played = notes_played + 1;
+						notes_played++;
+					}
+					if (rest_arr.includes(pitches.charAt(j))) {
+						notes_played++;
 					}
 				}
 			}

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -193,18 +193,14 @@ export default Marionette.ItemView.extend({
 		var cdb_uri = this.model.get('cdb_uri');
 		this.model.set({ 'cdb_link_url': 'https://cantus.uwaterloo.ca/node/' + cdb_uri })
 	},
+	ui : {
+		volpianoSyllables: ".volpiano-syllable"
+	},
 	events: {
-		"click #btnPlay": "submit"
+		"click .btnPlay": "submit"
 	},
 	submit: function mainPlay() {
-
-		//gets the single panel that is expanded
-		var expanded_panel = document.getElementsByClassName("panel-collapse collapse in");
-		var current_volpianos = expanded_panel[0].getElementsByClassName("volpiano-syllable");
-
-		var volArr = parse_volpiano(current_volpianos)
-
-		//var volTempo = 60.0/document.getElementById('myRange').value
-		volpiano2midi(volArr, .6)
+		var volArr = parse_volpiano(this.ui.volpianoSyllables);
+		volpiano2midi(volArr, .6);
 	}
 });

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -10,7 +10,7 @@ function dynamicallyLoadScript(url, onLoadFunction) {
 	if (onLoadFunction){
 		script.onload = onLoadFunction;
 	}
-	document.body.appendChild(script); // add it to the end of the head section of the page (could change 'head' to 'body' to add it to the end of the body section instead)
+	document.body.appendChild(script); // add it to the end of the body section of the page (could change 'body' to 'head' to add it to the end of the head section instead)
 }
 
 // Replacement for the built-in MIDI.noteOn function to 
@@ -133,9 +133,9 @@ function audioStopReset(MIDI){
 // a natural cancels it.
 function handleFlats (inputStr){
 	var flatReplDict = {};
-	flatReplDict["y"] = ["b","t"];
-	flatReplDict["i"] = ["j","u"];
-	flatReplDict["z"] = ["q","v"];
+	flatReplDict["y"] = ["b","t"]; // where flat is encoded as "y", change B3 to our make-shift encoding of Bb3
+	flatReplDict["i"] = ["j","u"]; // where flat is encoded as "i", change B4 to our make-shift encoding of Bb4
+	flatReplDict["z"] = ["q","v"]; // where flat is encoded as "z", change B5 to our make-shift encoding of Bb5
 	function applyFlat(inputStr, flatStr){
 		// find location of flat in syllable
 		var flatIndex = inputStr.indexOf(flatStr);

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -78,27 +78,8 @@ function volpiano2midi(input_arr, note_dur) {
 	pitch_dict['q'] = 71;
 	pitch_dict['r'] = 72;
 	pitch_dict['s'] = 74;
-	// add liquescent neumes to pitch dictionary
 	pitch_dict['('] = 41; // liquescent low f
 	pitch_dict[')'] = 43; // liquescent low g
-	pitch_dict['A'] = 45;
-	pitch_dict['B'] = 47;
-	pitch_dict['C'] = 48;
-	pitch_dict['D'] = 50;
-	pitch_dict['E'] = 52;
-	pitch_dict['F'] = 53;
-	pitch_dict['G'] = 55;
-	pitch_dict['H'] = 57;
-	pitch_dict['J'] = 59;
-	pitch_dict['K'] = 60;
-	pitch_dict['L'] = 62;
-	pitch_dict['M'] = 64;
-	pitch_dict['N'] = 65;
-	pitch_dict['O'] = 67;
-	pitch_dict['P'] = 69;
-	pitch_dict['Q'] = 71;
-	pitch_dict['R'] = 72;
-	pitch_dict['S'] = 74;
 
 	// create array of volpiano characters representing barlines
 	// for purposes of midi playback, these are treated as rests
@@ -119,11 +100,13 @@ function volpiano2midi(input_arr, note_dur) {
 				var vowel = input_arr[i][1]
 				MIDI.programChange(0, vowel);
 				//var notes_played = 0;
-				//iterate through each note pitch character, convert  lowercase, check if in dictionary, play the corresponding pitch
+				//iterate through each note pitch character, check if in dictionary, play the corresponding pitch
+				// characters in volpiano are converted to lowercase to play liquescent neumes, which 
+				// are indicated in volpiano by uppercase characters
 				for (var j = 0; j < pitches.length; j++) {
-					if (pitches.charAt(j) in pitch_dict) {
-						MIDI.noteOn(0, pitch_dict[pitches.charAt(j)], 127, notes_played * note_dur);
-						MIDI.noteOff(0, pitch_dict[pitches.charAt(j)], notes_played * note_dur + note_dur);
+					if (pitches.charAt(j).toLowerCase() in pitch_dict) {
+						MIDI.noteOn(0, pitch_dict[pitches.charAt(j).toLowerCase()], 127, notes_played * note_dur + 5);
+						MIDI.noteOff(0, pitch_dict[pitches.charAt(j).toLowerCase()], notes_played * note_dur + note_dur + 5);
 						notes_played++;
 					}
 					if (rest_arr.includes(pitches.charAt(j))) {
@@ -191,7 +174,7 @@ export default Marionette.ItemView.extend({
 		var formattedVolpiano = parseVolpianoSyllables(text, volpiano);
 		this.model.set('volpiano', formattedVolpiano);
 		var cdb_uri = this.model.get('cdb_uri');
-		this.model.set({ 'cdb_link_url': 'https://cantus.uwaterloo.ca/node/' + cdb_uri })
+		this.model.set({ 'cdb_link_url': 'https://cantus.uwaterloo.ca/node/' + cdb_uri });
 	},
 	ui : {
 		volpianoSyllables: ".volpiano-syllable",
@@ -209,6 +192,10 @@ export default Marionette.ItemView.extend({
 		volpiano2midi(volArr, .6);
 	},
 	stop: function stopPlay(){
+		var audioCxt = MIDI.getContext();
+		audioCxt.close();
+		var newAudioCxt = new window.AudioContext();
+		MIDI.setContext(newAudioCxt);
 		this.ui.btnPlay.html("Play Audio");
 		this.ui.btnPlay.attr("disabled", false);
 	}

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -194,13 +194,22 @@ export default Marionette.ItemView.extend({
 		this.model.set({ 'cdb_link_url': 'https://cantus.uwaterloo.ca/node/' + cdb_uri })
 	},
 	ui : {
-		volpianoSyllables: ".volpiano-syllable"
+		volpianoSyllables: ".volpiano-syllable",
+		btnPlay: ".btnPlay",
+		btnStop: ".btnStop"
 	},
 	events: {
-		"click .btnPlay": "submit"
+		"click .btnPlay": "submit",
+		"click .btnStop": "stop"
 	},
 	submit: function mainPlay() {
 		var volArr = parse_volpiano(this.ui.volpianoSyllables);
+		this.ui.btnPlay.html("Playing...");
+		this.ui.btnPlay.attr("disabled", true);
 		volpiano2midi(volArr, .6);
+	},
+	stop: function stopPlay(){
+		this.ui.btnPlay.html("Play Audio");
+		this.ui.btnPlay.attr("disabled", false);
 	}
 });

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -60,16 +60,26 @@ dynamicallyLoadScript('https://cdn.jsdelivr.net/gh/jacobsanz97/test502/js/midi/l
 	dynamicallyLoadScript('https://cdn.jsdelivr.net/gh/jacobsanz97/test502/js/midi/plugin.audiotag.js');
 	dynamicallyLoadScript('https://cdn.jsdelivr.net/gh/jacobsanz97/test502/js/midi/plugin.webmidi.js');
 	dynamicallyLoadScript('https://cdn.jsdelivr.net/gh/jacobsanz97/test502/js/midi/plugin.webaudio.js', function(){
-	MIDI.loadPlugin({
-		soundfontUrl: "https://cdn.jsdelivr.net/gh/jacobsanz97/test502/soundfont/",
-		instrument: "vowels",
-		onprogress: function (state, progress) {
-			console.log(state, progress);
-		}, onsuccess: function(){
-			MIDI.setVolume(0, 127);
+	MIDI.audioDetect(function (supports){
+		if (supports['audio/ogg']){
+			var soundfontUrl = "https://cdn.jsdelivr.net/gh/jacobsanz97/test502/soundfont/";
+			var instrument = "vowels";
+		} else if (supports['audio/mpeg']){
+			var soundfontUrl = "https://cdn.jsdelivr.net/gh/jacobsanz97/test502/soundfont_eg/";
+			var instrument = "acoustic_grand_piano";
 		}
+		MIDI.loadPlugin({
+			soundfontUrl: soundfontUrl,
+			instrument: instrument,
+			onprogress: function (state, progress) {
+				console.log(state, progress);
+			}, onsuccess: function(){
+				MIDI.setVolume(0, 127);
+			}
+		});
+		MIDI.NoteOn = replNoteOn;
+		MIDI.instrument = instrument;
 	});
-	MIDI.NoteOn = replNoteOn;
 });
 });
 });
@@ -194,7 +204,9 @@ function volpiano2midi(input_arr, note_dur) {
 			pitches = handleFlats(pitches);
 		}
 		var vowel = input_arr[i][1];
-		MIDI.programChange(0, vowel);
+		if (MIDI.instrument == "vowels"){
+			MIDI.programChange(0, vowel);
+		}
 		//var notes_played = 0;
 		//iterate through each note pitch character, check if in dictionary, play the corresponding pitch
 		// characters in volpiano are converted to lowercase to play liquescent neumes, which 

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -95,6 +95,7 @@ function volpiano2midi(input_arr, note_dur) {
 			//iterate through each syllable
 			MIDI.setVolume(0, 127);
 			var notes_played = 0;
+			var sources = [];
 			for (var i = 0; i < input_arr.length; i++) {
 				var pitches = input_arr[i][0]
 				var vowel = input_arr[i][1]
@@ -105,7 +106,8 @@ function volpiano2midi(input_arr, note_dur) {
 				// are indicated in volpiano by uppercase characters
 				for (var j = 0; j < pitches.length; j++) {
 					if (pitches.charAt(j).toLowerCase() in pitch_dict) {
-						MIDI.noteOn(0, pitch_dict[pitches.charAt(j).toLowerCase()], 127, notes_played * note_dur + 5);
+						var source = MIDI.noteOn(0, pitch_dict[pitches.charAt(j).toLowerCase()], 127, notes_played * note_dur + 5);
+						sources.push(source);
 						MIDI.noteOff(0, pitch_dict[pitches.charAt(j).toLowerCase()], notes_played * note_dur + note_dur + 5);
 						notes_played++;
 					}
@@ -114,6 +116,7 @@ function volpiano2midi(input_arr, note_dur) {
 					}
 				}
 			}
+			MIDI.sources = sources;
 		}
 	});
 };
@@ -194,6 +197,9 @@ export default Marionette.ItemView.extend({
 	stop: function stopPlay(){
 		var audioCxt = MIDI.getContext();
 		audioCxt.close();
+		for (var i = 0; i < MIDI.sources.length; i++){
+			MIDI.sources[i].disconnect();
+		}
 		var newAudioCxt = new window.AudioContext();
 		MIDI.setContext(newAudioCxt);
 		this.ui.btnPlay.html("Play Audio");

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -117,7 +117,7 @@ function volpiano2midi(input_arr, note_dur) {
 				//var notes_played = 0;
 				//iterate through each note pitch character, convert  lowercase, check if in dictionary, play the corresponding pitch
 				for (var j = 0; j < pitches.length; j++) {
-					if (pitches.charAt(j).toLowerCase() in pitch_dict) {
+					if (pitches.charAt(j) in pitch_dict) {
 						MIDI.noteOn(0, pitch_dict[pitches.charAt(j)], 127, notes_played * note_dur);
 						MIDI.noteOff(0, pitch_dict[pitches.charAt(j)], notes_played * note_dur + note_dur);
 						notes_played = notes_played + 1;

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -53,6 +53,18 @@ function CustomSplit(str, delimiter, removeEmptyItems) {
 	return result;
 }
 
+function audioStopReset(MIDI){
+	var audioCxt = MIDI.getContext();
+	audioCxt.close();
+	for (var i = 0; i < MIDI.sources.length; i++){
+		MIDI.sources[i].disconnect();
+	}
+	var newAudioCxt = new window.AudioContext();
+	MIDI.setContext(newAudioCxt);
+	$('.btnPlay').html("Play Audio");
+	$('.btnPlay').attr("disabled", false);
+}
+
 ///////////////////////////////////////////////////////////////////////////////////
 //Plays the volpiano notes using MIDI.js
 function volpiano2midi(input_arr, note_dur) {
@@ -117,6 +129,10 @@ function volpiano2midi(input_arr, note_dur) {
 				}
 			}
 			MIDI.sources = sources;
+			// add an ended event listener to the final note
+			MIDI.sources[MIDI.sources.length - 1].addEventListener("ended", function(event){
+				audioStopReset(MIDI);
+			})
 		}
 	});
 };
@@ -194,15 +210,7 @@ export default Marionette.ItemView.extend({
 		this.ui.btnPlay.attr("disabled", true);
 		volpiano2midi(volArr, .6);
 	},
-	stop: function stopPlay(){
-		var audioCxt = MIDI.getContext();
-		audioCxt.close();
-		for (var i = 0; i < MIDI.sources.length; i++){
-			MIDI.sources[i].disconnect();
-		}
-		var newAudioCxt = new window.AudioContext();
-		MIDI.setContext(newAudioCxt);
-		this.ui.btnPlay.html("Play Audio");
-		this.ui.btnPlay.attr("disabled", false);
+	stop: function(){
+		audioStopReset(MIDI);
 	}
 });

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -177,6 +177,6 @@ export default Marionette.ItemView.extend({
 		var volArr = parse_volpiano(current_volpianos)
 
 		//var volTempo = 60.0/document.getElementById('myRange').value
-		volpiano2midi(volArr, 1.0)
+		volpiano2midi(volArr, .6)
 	}
 });

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -78,6 +78,27 @@ function volpiano2midi(input_arr, note_dur) {
 	pitch_dict['q'] = 71;
 	pitch_dict['r'] = 72;
 	pitch_dict['s'] = 74;
+	// add liquescent neumes to pitch dictionary
+	pitch_dict['('] = 41; // liquescent low f
+	pitch_dict[')'] = 43; // liquescent low g
+	pitch_dict['A'] = 45;
+	pitch_dict['B'] = 47;
+	pitch_dict['C'] = 48;
+	pitch_dict['D'] = 50;
+	pitch_dict['E'] = 52;
+	pitch_dict['F'] = 53;
+	pitch_dict['G'] = 55;
+	pitch_dict['H'] = 57;
+	pitch_dict['J'] = 59;
+	pitch_dict['K'] = 60;
+	pitch_dict['L'] = 62;
+	pitch_dict['M'] = 64;
+	pitch_dict['N'] = 65;
+	pitch_dict['O'] = 67;
+	pitch_dict['P'] = 69;
+	pitch_dict['Q'] = 71;
+	pitch_dict['R'] = 72;
+	pitch_dict['S'] = 74;
 
 	MIDI.loadPlugin({
 		soundfontUrl: "https://cdn.jsdelivr.net/gh/jacobsanz97/test502/soundfont/",

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
@@ -43,5 +43,5 @@
 <hr/>
 <div class="volpiano"><%= volpiano %></div>
 <hr/>
-<button id="btnPlay">Play Audio</button>
+<button class="btnPlay">Play Audio</button>
 <% } %>

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
@@ -44,4 +44,5 @@
 <div class="volpiano"><%= volpiano %></div>
 <hr/>
 <button class="btnPlay">Play Audio</button>
+<button class="btnStop">Stop Audio</button>
 <% } %>


### PR DESCRIPTION
Closes #312. 

Makes the following additions/fixes:
- Introduces a stop button to halt midi playback.
- Adjusts behaviour of the play button to prevent multiple simultaneous/overlapping plays.
- Speeds up chant playback.
- Modifies plug-in load process to reduce speed of load time on playback initiation and improve page load consistency.
- Introduces handling of liquescent neumes, flats, and barlines.
- Adds support for browsers using mpeg.
- Removes Play button when no volpiano is available.
- Fixes playback timing to remove note bunching at the beginning of playback.