### PR TITLE
Issue 633 about volpiano popup

### DIFF
--- a/app/public/cantusdata/templates/base.html
+++ b/app/public/cantusdata/templates/base.html
@@ -60,6 +60,7 @@
                 </div>
             </nav>
             <div id="search-modal"></div>
+            <div id="about-volpiano-modal"></div>
         </div>
     </div>
 

--- a/nginx/public/node/frontend/public/css/styles.scss
+++ b/nginx/public/node/frontend/public/css/styles.scss
@@ -141,6 +141,15 @@ pre.preformatted-text {
     left: 0;
 }
 
+.volpiano-text-lg {
+    font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    margin-top: 35px;
+    margin-bottom: 35px;
+    position: absolute;
+    left: 0;
+}
+
 .field-volpiano, .field-volpiano_literal {
     color: #333;
 }

--- a/nginx/public/node/frontend/public/css/styles.scss
+++ b/nginx/public/node/frontend/public/css/styles.scss
@@ -257,7 +257,7 @@ pre.preformatted-text {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    overflow: hidden;
+    overflow: scroll;
 
     // Workaround for Safari, where elements would shrink if the chant list was too big
     > * {

--- a/nginx/public/node/frontend/public/js/app/layout/HeaderView.js
+++ b/nginx/public/node/frontend/public/js/app/layout/HeaderView.js
@@ -49,7 +49,7 @@ export default Marionette.LayoutView.extend({
         });
 
         // The modal box for the search pop-up
-        this.searchModalView = new ModalView({title: "Search", view: this.searchView});
+        this.searchModalView = new ModalView({title: "Search", view: this.searchView, modalId: "searchModal"});
     },
 
     /**
@@ -93,7 +93,7 @@ export default Marionette.LayoutView.extend({
     {
         var searchModalAttrs = {
             'data-toggle': 'modal',
-            href: '#myModal'
+            href: '#searchModal'
         };
 
         // Dynamically make the search link a modal

--- a/nginx/public/node/frontend/public/js/app/layout/HeaderView.js
+++ b/nginx/public/node/frontend/public/js/app/layout/HeaderView.js
@@ -3,6 +3,7 @@ import Radio from "backbone.radio";
 
 import SearchView from "search/SearchView";
 import ChantSearchProvider from "search/chant-search/ChantSearchProvider";
+import AboutVolpianoView from "search/chant-search/AboutVolpianoView";
 
 import ModalView from "./ModalView";
 
@@ -23,7 +24,8 @@ export default Marionette.LayoutView.extend({
 
     regions: {
         pageTitle: '#page-title',
-        searchModalRegion: '#search-modal'
+        searchModalRegion: '#search-modal',
+        aboutVolpianoModalRegion: '#about-volpiano-modal'
     },
 
     ui: {
@@ -50,6 +52,9 @@ export default Marionette.LayoutView.extend({
 
         // The modal box for the search pop-up
         this.searchModalView = new ModalView({title: "Search", view: this.searchView, modalId: "searchModal"});
+
+        this.aboutVolpianoView = new AboutVolpianoView();
+        this.aboutVolpianoModalView = new ModalView({title: "About Volpiano", view: this.aboutVolpianoView, modalId: "aboutVolModal"});
     },
 
     /**
@@ -117,10 +122,12 @@ export default Marionette.LayoutView.extend({
         });
 
         this.searchModalRegion.show(this.searchModalView, {preventDestroy: true});
+        this.aboutVolpianoModalRegion.show(this.aboutVolpianoModalView, {preventDestroy: true});
     },
 
     onDestroy: function ()
     {
         this.searchModalView.destroy();
+        this.aboutVolpianoModalView.destroy();
     }
 });

--- a/nginx/public/node/frontend/public/js/app/layout/ModalView.js
+++ b/nginx/public/node/frontend/public/js/app/layout/ModalView.js
@@ -1,4 +1,5 @@
 import Marionette from "marionette";
+import $ from 'jquery';
 
 import template from './modal.template.html';
 
@@ -17,6 +18,10 @@ export default Marionette.LayoutView.extend({
 
     regions: {
         body: '.modal-body'
+    },
+
+    events: {
+        "hidden.bs.modal": "modalDismissCallback"
     },
 
     initialize: function(options)
@@ -41,5 +46,13 @@ export default Marionette.LayoutView.extend({
             title: this.title,
             modalId: this.modalId
         };
+    },
+
+    modalDismissCallback: function(event){
+        if (this.modalId == "aboutVolModal"){
+            if ($('#manuscript-search-pane').length == 0){
+                $('#searchModal').modal('show');
+            }
+        }
     }
 });

--- a/nginx/public/node/frontend/public/js/app/layout/ModalView.js
+++ b/nginx/public/node/frontend/public/js/app/layout/ModalView.js
@@ -11,6 +11,7 @@ import template from './modal.template.html';
 export default Marionette.LayoutView.extend({
     title: null,
     visitorView: null,
+    modalId: null,
 
     template,
 
@@ -22,6 +23,7 @@ export default Marionette.LayoutView.extend({
     {
         this.title = options.title;
         this.visitorView = options.view;
+        this.modalId = options.modalId;
     },
 
     onRender: function()
@@ -36,7 +38,8 @@ export default Marionette.LayoutView.extend({
     serializeData: function()
     {
         return {
-            title: this.title
+            title: this.title,
+            modalId: this.modalId
         };
     }
 });

--- a/nginx/public/node/frontend/public/js/app/layout/modal.template.html
+++ b/nginx/public/node/frontend/public/js/app/layout/modal.template.html
@@ -2,7 +2,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <button type="button" class="close" style = "color:#000" data-dismiss="modal" aria-hidden="true">&times;</button>
                 <h4 class="modal-title"><%= title %></h4>
             </div>
             <div class="modal-body"></div>

--- a/nginx/public/node/frontend/public/js/app/layout/modal.template.html
+++ b/nginx/public/node/frontend/public/js/app/layout/modal.template.html
@@ -1,9 +1,9 @@
-<div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div class="modal fade" id= <%= modalId %> tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h4 class="modal-title" id="myModalLabel"><%= title %></h4>
+                <h4 class="modal-title"><%= title %></h4>
             </div>
             <div class="modal-body"></div>
         </div>

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/AboutVolpianoView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/AboutVolpianoView.js
@@ -1,0 +1,8 @@
+import _ from "underscore";
+import Marionette from "marionette";
+
+import template from './about-volpiano.template.html';
+
+export default Marionette.ItemView.extend({
+ template,
+});

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/AboutVolpianoView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/AboutVolpianoView.js
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import Marionette from "marionette";
 
 import template from './about-volpiano.template.html';

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/about-volpiano.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/about-volpiano.template.html
@@ -7,7 +7,7 @@
         </p>
         <p>
             With Volpiano, alphanumeric characters and other symbols are
-            rendered as pitches and other musical elements on standard staffs.
+            rendered as pitches and other musical elements on standard staves.
             On Cantus Ultimus, you can use Volpiano to enter a certain melody
             and search for that melody in available manuscripts.
         </p>
@@ -55,18 +55,24 @@
                 a single neume, and the second will only return chants where the
                 pitches occur in two consecutive two-pitch neumes.
                 <div class="volpiano" style="text-align:center"><div
-                        class="volpiano-syllable">1---fgfh---33---fg-fh--</div>
+                        class="volpiano-syllable">1---fgfh---33</div><div
+                        class="volpiano-syllable">
+                        1---fg-fh---
+                    </div>
                 </div>
             </li>
             <li>
-                Volpiano search is not octave dependent. For example, the first
-                query below will return a chant with a sequence of the pitches F
+                Volpiano search is not octave dependent. For example, this
+                query will return a chant with a sequence of the pitches F
                 and G in
-                any octave. The second search will return a chant with a
+                any octave.
+                <div class="volpiano" style="text-align:center"><div
+                        class="volpiano-syllable">1---fg---</div></div>
+                Similarly, this query will return a chant with a
                 sequence of
                 pitches E and D in any octave.
                 <div class="volpiano" style="text-align:center"><div
-                        class="volpiano-syllable">1---fg---33---el---</div></div>
+                        class="volpiano-syllable">1---el---</div></div>
             </li>
             <li>
                 Liquescents are shown as smaller noteheads in Volpiano results.

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/about-volpiano.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/about-volpiano.template.html
@@ -1,1 +1,90 @@
-More information about volpiano goes here
+<div class="container-fluid">
+    <div class="row">
+        <p>
+            Volpiano is a font that was created for the transcription of chant
+            melodies. It was developed Fabian Weber at the University of
+            Regensburg under the direction of David Hiley.
+        </p>
+        <p>
+            With Volpiano, alphanumeric characters and other symbols are
+            rendered as pitches and other musical elements on standard staffs.
+            On Cantus Ultimus, you can use Volpiano to enter a certain melody
+            and search for that melody in available manuscripts.
+        </p>
+
+
+        <p><b>Volpiano Dictionary</b></p>
+
+        <p>Queries can be entered using the characters below.</p>
+    </div>
+    <div class="row justify-content-center" style="margin-bottom:20pt">
+        <div class="volpiano" style="text-align:center">
+            <div class="volpiano-syllable">1---</div><div
+                class="volpiano-syllable">e--<span
+                    class="volpiano-text-lg">e</span></div><div
+                class="volpiano-syllable">f--<span
+                    class="volpiano-text-lg">f</span></div><div
+                class="volpiano-syllable">g--<span
+                    class="volpiano-text-lg">g</span></div><div
+                class="volpiano-syllable">h--<span
+                    class="volpiano-text-lg">h</span></div><div
+                class="volpiano-syllable">j--<span
+                    class="volpiano-text-lg">j</span></div><div
+                class="volpiano-syllable">k--<span
+                    class="volpiano-text-lg">k</span></div><div
+                class="volpiano-syllable">l--<span
+                    class="volpiano-text-lg">l</span></div><div
+                class="volpiano-syllable">i--<span
+                    class="volpiano-text-lg">i</span></div><div
+                class="volpiano-syllable">I--<span
+                    class="volpiano-text-lg">I</span></div>
+        </div>
+    </div>
+    <div class="row">
+        <p><b>Features of Volpiano Search</b></p>
+        <ol>
+            <li>
+                There are two types of Volpiano search in Cantus Ultimus:
+                "Volpiano" and "Volpiano (Literal)." "Volpiano (Literal)"
+                matches the way pitches in the query are divided into neumes. In
+                Volpiano, a hyphen ("-") separates pitches belonging to
+                different neumes. For example, the two queries below will yield
+                the same results in a "Volpiano" search, but not in a "Volpiano
+                (Literal)" search. In a "Volpiano (Literal)" search, the first
+                query will only return chants in which those four pitches occur
+                a single neume, and the second will only return chants where the
+                pitches occur in two consecutive two-pitch neumes.
+                <div class="volpiano" style="text-align:center"><div
+                        class="volpiano-syllable">1---fgfh---33---fg-fh--</div>
+                </div>
+            </li>
+            <li>
+                Volpiano search is not octave dependent. For example, the first
+                query below will return a chant with a sequence of the pitches F
+                and G in
+                any octave. The second search will return a chant with a
+                sequence of
+                pitches E and D in any octave.
+                <div class="volpiano" style="text-align:center"><div
+                        class="volpiano-syllable">1---fg---33---el---</div></div>
+            </li>
+            <li>
+                Liquescents are shown as smaller noteheads in Volpiano results.
+                For the purposes of search, however, liquescents are treated as
+                regular notes. For example, searching the string
+                <div class="volpiano" style="text-align:center"><div
+                        class="volpiano-syllable">1---gf---</div></div>
+                could return a chant that includes
+                <div class="volpiano" style="text-align:center"><div
+                        class="volpiano-syllable">1---gF---</div></div>
+            </li>
+            <li>
+                Accidentals are encoded according to their position in the
+                manuscript,
+                and therefore might not immediately preceed the note they
+                effect. Just like notes, volpiano search does not specify the
+                octave in which the accidental occurs.
+            </li>
+        </ol>
+    </div>
+</div>

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/about-volpiano.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/about-volpiano.template.html
@@ -1,0 +1,1 @@
+More information about volpiano goes here

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/search-input.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/search-input.template.html
@@ -28,5 +28,5 @@
     </div>
 </form>
 <% if (field == 'volpiano' || field == 'volpiano_literal' ) { %>
-    <a href="#" class="about-volpiano-modal-link" data-toggle="modal" data-target="#aboutVolModal"> About Volpiano </a>
+    <a href="#" class="about-volpiano-modal-link" data-toggle="modal" data-target="#aboutVolModal" data-dismiss="modal"> About Volpiano </a>
 <% } %>

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/search-input.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/search-input.template.html
@@ -27,3 +27,6 @@
         <% } %>
     </div>
 </form>
+<% if (field == 'volpiano' || field == 'volpiano_literal' ) { %>
+    <a href="#" class="about-volpiano-modal-link" data-toggle="modal" data-target="#aboutVolModal"> About Volpiano </a>
+<% } %>


### PR DESCRIPTION
This PR partially addresses #633 by creating a pop-up modal for additional information about Volpiano search on Cantus Ultimus. Before that issue is closed, the contents of the pop-up box should be reviewed and revised. 

Some features of this request:
- Creates a modal box that is accessed by a link that appears whenever Volpiano or Volpiano (Literal) search types are selected.
- Adjusts modal view to allow for multiple modals on the same page (Note: Our framework continues to only support opening a single modal at a time).
- Makes visible the "x" button to close all modals.
- Reopens a Search modal when the About Volpiano modal is closed if the search interface was in a modal (ie. if search is accessed from the main navbar rather than the manuscript detail view).
- Provides a draft of some "About Volpiano" text, including a review of important aspects of the way volpiano search is implemented in Cantus Ultimus.