### PR TITLE
Make chant accordion header clickable

### DIFF
--- a/nginx/public/node/frontend/public/css/styles.scss
+++ b/nginx/public/node/frontend/public/css/styles.scss
@@ -171,6 +171,22 @@ pre.preformatted-text {
     line-height: 1.42857143;
 }
 
+.chant-list-region .panel-heading {
+    color: #333333;
+    background-color: #f5f5f5;
+    border-color: #dddddd;
+    text-decoration: none;
+
+    &:hover{
+        background:#fcfcfc;
+        color:#c2342e;
+    }
+}
+
+.chant-list-region a:hover, a:focus{
+    text-decoration: none;
+}
+
 .result-list {
     > thead > tr > th {
         white-space: nowrap;

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-item.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-item.template.html
@@ -1,9 +1,9 @@
 <a data-toggle="collapse" data-parent=".accordion" href="#collapse-<%= item_id %>">
-<div class="panel-heading">
-    <h4 class="panel-title">
-        <%= incipit %>
-    </h4>
-</div>
+    <div class="panel-heading">
+        <h4 class="panel-title">
+            <%= incipit %>
+        </h4>
+    </div>
 </a>
 <div id="collapse-<%= item_id %>" class="panel-collapse collapse <%= isOpen() ? 'in' : '' %>">
     <div class="panel-body"></div>

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-item.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-item.template.html
@@ -1,10 +1,10 @@
+<a data-toggle="collapse" data-parent=".accordion" href="#collapse-<%= item_id %>">
 <div class="panel-heading">
     <h4 class="panel-title">
-        <a data-toggle="collapse" data-parent=".accordion" href="#collapse-<%= item_id %>" style="display:block">
-            <%= incipit %>
-        </a>
+        <%= incipit %>
     </h4>
 </div>
+</a>
 <div id="collapse-<%= item_id %>" class="panel-collapse collapse <%= isOpen() ? 'in' : '' %>">
     <div class="panel-body"></div>
 </div>

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-item.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-item.template.html
@@ -1,6 +1,6 @@
 <div class="panel-heading">
     <h4 class="panel-title">
-        <a data-toggle="collapse" data-parent=".accordion" href="#collapse-<%= item_id %>">
+        <a data-toggle="collapse" data-parent=".accordion" href="#collapse-<%= item_id %>" style="display:block">
             <%= incipit %>
         </a>
     </h4>


### PR DESCRIPTION
Closes #650 by:

- wrapping the entire chant accordion div in an anchor tag, opening the chant detail panel
- modifying our customized css to match styling to the older version