### PR TITLE
Fix typo for CH-Fco Ms. 2 in manifests.csv

### DIFF
--- a/app/public/data_dumps/manifests.csv
+++ b/app/public/data_dumps/manifests.csv
@@ -11,7 +11,7 @@ CDN-Hsmu M2149.L4,https://lib.is/IE9434868/manifest
 CDN-Mlr MS 073,https://iiif.archivelab.org/iiif/McGillLibrary-rbsc_ms-medieval-073-18802/manifest.json
 CH-E 121,https://www.e-codices.unifr.ch/metadata/iiif/sbe-0121/manifest.json 
 CH-E 611,http://www.e-codices.unifr.ch/metadata/iiif/sbe-0611/manifest.json 
-CH-Fco 2,https://www.e-codices.unifr.ch/metadata/iiif/fcc-0002/manifest.json
+CH-Fco Ms. 2,https://www.e-codices.unifr.ch/metadata/iiif/fcc-0002/manifest.json
 CH-Ff Ms. 9,https://www.e-codices.unifr.ch/metadata/iiif/fcc-0009/manifest.json
 CH-P 18,https://www.e-codices.unifr.ch/metadata/iiif/bcj-0018/manifest.json 
 CH-SGs 359,https://www.e-codices.unifr.ch/metadata/iiif/csg-0359/manifest.json 


### PR DESCRIPTION
The IIIF manifest for CH-Fco Ms 2 (Fribourg) was not automatically importing, because the siglum in manifests.csv did not match the siglum in Cantus DB.