### PR TITLE
Specify version of postgres in Dockerfile

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres
+FROM postgres:14
 EXPOSE 5432
 CMD ["postgres"]


### PR DESCRIPTION
The Dockerfile for the postgres container should specify the version of postgres to build from (which is also, of course, the version of postgres being used on the site, which is good to have recorded in version control).