### PR TITLE
Import manuscript data using CantusDB APIs

### DIFF
--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -1,0 +1,70 @@
+from urllib import request
+import json
+
+class SourceImporter:
+    """
+    Imports sources from CantusDB by way of its APIs.
+
+    :param str cantus_db_base_url: the domain for CantusDB.
+    """
+    def __init__(self, cantus_db_base_url):
+        self.cdb_base_url = cantus_db_base_url
+
+    def request_source_ids(self):
+        """
+        Requests the IDs of all sources available in CantusDB
+        
+        :return: a list of character source ID's
+        """
+        sources_url = self.cdb_base_url + "/json-sources/"
+        sources_response = request.urlopen(sources_url).read()
+        sources_json = json.loads(sources_response)
+        source_ids = sources_json.keys()
+        return source_ids
+
+    def request_source_data(self, source_id):
+        """
+        Requests data on an individual source in CantusDB using
+        the /json-node/ endpoint.
+        
+        :param str source_id: the ID of the source in CantusDB
+        :return: a parsed json object containing source data
+        """
+        source_url = self.cdb_base_url + "/json-node/" + source_id
+        source_response = request.urlopen(source_url).read()
+        source_json = json.loads(source_response)
+        return source_json
+
+    def source_json_extractor(source_json):
+        """
+        Extracts required elements for the CU Manuscript
+        model from the API response json.
+
+        :param json source_json: parsed json response from json-node api
+        :return: a dictionary of Manuscript attributes
+        """
+        source_dict = {}
+        source_dict["id"] = source_json["vid"]
+        source_dict["name"] = source_json["title"]
+        source_dict["siglum"] = source_json["field_siglum"]["und"][0]["value"]
+        source_dict["date"] = source_json["field_date"]["und"][0]["value"]
+        source_dict["provenance"] = source_json["field_provenance"]["und"][0]["value"]
+        source_dict["description"] = source_json["field_summary"]["und"][0]["value"]
+        return source_dict
+        
+    def collect_sources(self):
+        """
+        Collects data on all sources in CantusDB for for importing
+        into Cantus Ultimus.
+
+        :return: a list of dictionaries with metadata on each source
+        """
+        source_ids = self.request_source_ids()
+        source_list = []
+        for id in source_ids:
+            source_json = self.request_source_data(id)
+            source_attrs = self.source_json_extractor(source_json)
+            source_list.append(source_attrs)
+        return source_list
+            
+            

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -10,13 +10,13 @@ class ProvenanceParser(HTMLParser):
     provenance_div flags whether the parser has reached the div containing the 
     provenance text.
     
-    is_provenance flags whether the parser has reached the anchor tag that contains 
+    provenance_a flags whether the parser has reached the anchor tag that contains 
     the provenance text.
     """
     def __init__(self):
         super().__init__()
         self.provenance_div = False
-        self.is_provenance = False
+        self.provenance_a = False
         self.provenance = ""
 
     def handle_starttag(self, tag, attrs):
@@ -26,14 +26,14 @@ class ProvenanceParser(HTMLParser):
         class attributes assigned to the div that contains provenance data. If
         this div is encountered, the provenance_div flag is set to True.
         2. if a anchor tag is encountered within this div tag, set the 
-        is_provenance flag to True.
+        provenance_a flag to True.
         """
         if tag == "div":
             if ("class","views-field views-field-field-provenance-tax") in attrs:
                 self.provenance_div = True
         if tag == "a":
             if self.provenance_div:
-                self.is_provenance = True
+                self.provenance_a = True
 
     def handle_endtag(self, tag):
         """
@@ -41,13 +41,13 @@ class ProvenanceParser(HTMLParser):
         """
         if self.is_provenance:
             self.provenance_div = False
-            self.is_provenance = False
+            self.provenance_a = False
     
     def handle_data(self, data):
         """
-        Extract the provenance data when is_provenance has been triggered.
+        Extract the provenance data when provenance_a has been triggered.
         """
-        if self.is_provenance:
+        if self.provenance_a:
             self.provenance = data
 
 class SourceImporter:

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -74,7 +74,6 @@ class SourceImporter:
         """
         source_pg_url = self.cdb_base_url + "/source/" + source_id
         source_pg_response = request.urlopen(source_pg_url).read().decode()
-        #import pdb; pdb.set_trace()
         source_pg_html = ProvenanceParser()
         source_pg_html.feed(source_pg_response)
         return source_pg_html.provenance

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -3,26 +3,50 @@ import json
 from html.parser import HTMLParser
 
 class ProvenanceParser(HTMLParser):
+    """
+    ProvenanceParser extracts the short provenance name from a CantusDB source
+    page (/source/id-of-source/). 
+    
+    provenance_div flags whether the parser has reached the div containing the 
+    provenance text.
+    
+    is_provenance flags whether the parser has reached the anchor tag that contains 
+    the provenance text.
+    """
     def __init__(self):
         super().__init__()
-        self.provenance_class = False
+        self.provenance_div = False
         self.is_provenance = False
         self.provenance = ""
 
     def handle_starttag(self, tag, attrs):
+        """
+        While parsing the html:
+        1. determine whether a div tag encountered by the parser has the unique
+        class attributes assigned to the div that contains provenance data. If
+        this div is encountered, the provenance_div flag is set to True.
+        2. if a anchor tag is encountered within this div tag, set the 
+        is_provenance flag to True.
+        """
         if tag == "div":
             if ("class","views-field views-field-field-provenance-tax") in attrs:
-                self.provenance_class = True
+                self.provenance_div = True
         if tag == "a":
-            if self.provenance_class:
+            if self.provenance_div:
                 self.is_provenance = True
 
     def handle_endtag(self, tag):
+        """
+        Once provenance data has been extracted, set the flags to False
+        """
         if self.is_provenance:
-            self.provenance_class = False
+            self.provenance_div = False
             self.is_provenance = False
     
     def handle_data(self, data):
+        """
+        Extract the provenance data when is_provenance has been triggered.
+        """
         if self.is_provenance:
             self.provenance = data
 

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -47,7 +47,7 @@ class SourceImporter:
         source_ids = sources_json.keys()
         return source_ids
 
-    def source_data_download(self, source_id):
+    def download_source_data(self, source_id):
         """
         Requests data on an individual source in CantusDB using
         the /json-node/ endpoint.
@@ -60,7 +60,7 @@ class SourceImporter:
         source_json = json.loads(source_response)
         return source_json
     
-    def source_provenance_download(self, source_id):
+    def download_source_provenance(self, source_id):
         """
         The current Old CantusDB API endpoints do not provide
         a method for obtaining Provenance metadata (the text returned
@@ -79,7 +79,7 @@ class SourceImporter:
         source_pg_html.feed(source_pg_response)
         return source_pg_html.provenance
 
-    def source_json_extractor(self, source_json):
+    def extract_source_data(self, source_json):
         """
         Extracts required elements for the CU Manuscript
         model from the API response json.
@@ -103,7 +103,7 @@ class SourceImporter:
         #     source_dict["provenance"] = source_json["field_provenance"]["und"][0]["value"]
         # else:
         #     source_dict["provenance"] = ""
-        source_dict["provenance"] = self.source_provenance_download(source_dict["id"])
+        source_dict["provenance"] = self.download_source_provenance(source_dict["id"])
         if source_json["field_summary"]:
             source_dict["description"] = source_json["field_summary"]["und"][0]["value"]
         else:
@@ -119,6 +119,6 @@ class SourceImporter:
         :return: a dictionary of metadata for use in creating a
         Manuscript object in Cantus Ultimus
         """
-        source_json = self.source_data_download(source_id)
-        source_data = self.source_json_extractor(source_json)
+        source_json = self.download_source_data(source_id)
+        source_data = self.extract_source_data(source_json)
         return source_data

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -39,7 +39,7 @@ class ProvenanceParser(HTMLParser):
         """
         Once provenance data has been extracted, set the flags to False
         """
-        if self.is_provenance:
+        if self.provenance_a:
             self.provenance_div = False
             self.provenance_a = False
     

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -41,7 +41,7 @@ class SourceImporter:
         
         :return: a list of character source ID's
         """
-        sources_url = self.cdb_base_url + "/json-sources/"
+        sources_url = f"{self.cdb_base_url}/json-sources/"
         sources_response = request.urlopen(sources_url).read()
         sources_json = json.loads(sources_response)
         source_ids = sources_json.keys()
@@ -55,7 +55,7 @@ class SourceImporter:
         :param str source_id: the ID of the source in CantusDB
         :return: a parsed json object containing source data
         """
-        source_url = self.cdb_base_url + "/json-node/" + source_id
+        source_url = f"{self.cdb_base_url}/json-node/{source_id}"
         source_response = request.urlopen(source_url).read()
         source_json = json.loads(source_response)
         return source_json
@@ -72,7 +72,7 @@ class SourceImporter:
         (see https://github.com/DDMAL/CantusDB/issues/564), so this will be
         simplified once that is complete.
         """
-        source_pg_url = self.cdb_base_url + "/source/" + source_id
+        source_pg_url = f"{self.cdb_base_url}/source/{source_id}"
         source_pg_response = request.urlopen(source_pg_url).read().decode()
         source_pg_html = ProvenanceParser()
         source_pg_html.feed(source_pg_response)
@@ -111,8 +111,9 @@ class SourceImporter:
             
     def get_source_data(self, source_id):
         """
-        Given a CantusDB, returns a dictionary of source metadata 
-        required to create a Cantus Ultimus manuscript object.
+        Given a source ID from CantusDB, returns a dictionary of 
+        source metadata required to create a Cantus Ultimus 
+        manuscript object.
 
         :param str source_id: the ID of the source in CantusDB
         :return: a dictionary of metadata for use in creating a

--- a/app/public/cantusdata/management/commands/import_data.py
+++ b/app/public/cantusdata/management/commands/import_data.py
@@ -90,8 +90,8 @@ class Command(BaseCommand):
                 # Getting the fields from the scraper
                 id = source.get("id")
                 name = source.get("name")
-                cantus_url = cdb_base_url + "source/" + id
-                csv_export_url = cdb_base_url + "sites/default/files/csv/" + id + ".csv"
+                cantus_url = f"{cdb_base_url}source/{id}"
+                csv_export_url = f"{cdb_base_url}sites/default/files/csv/{id}.csv"
                 siglum = source.get("siglum")
                 date = source.get("date")
                 provenance = source.get("provenance")
@@ -108,15 +108,15 @@ class Command(BaseCommand):
                 manuscript.description = description
                 manuscript.is_mapped = "UNMAPPED"
                 manuscript.save()
-                self.stdout.write(source["id"] + " " + source["name"])
+                self.stdout.write(f'{source["id"]} {source["name"]}')
                 i += 1
             except urllib.error.HTTPError as http_error:
                 if http_error.code == 403:
-                    self.stdout.write("FORBIDDEN: " + source_id)
+                    self.stdout.write(f"FORBIDDEN: {source_id}")
                 else:
-                    self.stdout.write("FAILED: " + source_id)
+                    self.stdout.write(f"FAILED: {source_id}")
         self.stdout.write(
-            "Successfully imported {} manuscripts into database.".format(i)
+            f"Successfully imported {i} manuscripts into database."
         )
 
     @transaction.atomic

--- a/app/public/cantusdata/management/commands/import_data.py
+++ b/app/public/cantusdata/management/commands/import_data.py
@@ -7,9 +7,10 @@ from cantusdata.models.manuscript import Manuscript
 from cantusdata.signals.solr_sync import solr_synchronizer
 from cantusdata.helpers.chant_importer import ChantImporter
 from cantusdata.helpers.scrapers.sources import sources
-from cantusdata.helpers.scrapers.manuscript import parse as parse_manuscript
+from cantusdata.helpers.source_importer import SourceImporter
 from cantusdata.helpers.scrapers.concordances import concordances
 import urllib.request
+import urllib
 from io import StringIO
 from cantusdata.settings import BASE_DIR
 from os import path
@@ -79,30 +80,41 @@ class Command(BaseCommand):
     @transaction.atomic
     def import_manuscript_data(self, **options):
         self.stdout.write("Starting manuscript import process.")
+        cdb_base_url = "https://cantus.uwaterloo.ca/"
+        source_importer = SourceImporter(cdb_base_url)
+        source_ids = source_importer.request_source_ids()
         i = 0
-        for source, name in sources.items():
-            self.stdout.write(source + " " + name)
-            # Getting the fields from the scraper
-            metadata = parse_manuscript(source)
-            name = metadata.get("Title", "")
-            cantus_url = metadata.get("CantusURL", "")
-            csv_export_url = metadata.get("CSVExport", "")
-            siglum = metadata.get("Siglum", "")
-            date = metadata.get("Date", "")
-            provenance = metadata.get("Provenance", "")
-            description = metadata.get("Summary", "")
-            # Populating the Manuscript model
-            manuscript = Manuscript()
-            manuscript.name = name
-            manuscript.cantus_url = cantus_url
-            manuscript.csv_export_url = csv_export_url
-            manuscript.siglum = siglum
-            manuscript.date = date
-            manuscript.provenance = provenance
-            manuscript.description = description
-            manuscript.is_mapped = "UNMAPPED"
-            manuscript.save()
-            i += 1
+        for source_id in source_ids:
+            try:
+                source = source_importer.get_source_data(source_id)
+                # Getting the fields from the scraper
+                id = source.get("id")
+                name = source.get("name")
+                cantus_url = cdb_base_url + "source/" + id
+                csv_export_url = cdb_base_url + "sites/default/files/csv/" + id + ".csv"
+                siglum = source.get("siglum")
+                date = source.get("date")
+                provenance = source.get("provenance")
+                description = source.get("description")
+                # Populating the Manuscript model
+                manuscript = Manuscript()
+                manuscript.id = int(id)
+                manuscript.name = name
+                manuscript.cantus_url = cantus_url
+                manuscript.csv_export_url = csv_export_url
+                manuscript.siglum = siglum
+                manuscript.date = date
+                manuscript.provenance = provenance
+                manuscript.description = description
+                manuscript.is_mapped = "UNMAPPED"
+                manuscript.save()
+                self.stdout.write(source["id"] + " " + source["name"])
+                i += 1
+            except urllib.error.HTTPError as http_error:
+                if http_error.code == 403:
+                    self.stdout.write("FORBIDDEN: " + source_id)
+                else:
+                    self.stdout.write("FAILED: " + source_id)
         self.stdout.write(
             "Successfully imported {} manuscripts into database.".format(i)
         )

--- a/app/public/cantusdata/models/manuscript.py
+++ b/app/public/cantusdata/models/manuscript.py
@@ -28,6 +28,7 @@ class Manuscript(models.Model):
             )
         ]
 
+    id = models.IntegerField(primary_key = True)
     name = models.CharField(max_length=255, blank=True, null=True)
     siglum = models.CharField(max_length=255, blank=True, null=True)
     date = models.CharField(max_length=50, blank=True, null=True)


### PR DESCRIPTION
This PR modifies the manuscript data import process so that manuscript data is obtained (primarily) through CantusDB's API's. 

With this PR, we:
- minimize the use of CantusDB html as a source of manuscript metadata
- obtain source id's from CantusDB for all manuscripts and use those id's, rather than Django's built-in auto-incrementing id, for manuscript objects in the Cantus Ultimus database. As such, this is a partial fix for #652.

The manuscript data import process still uses html parsing to obtain a manuscript's provenance attribute, as this is not currently available through CantusDB's API. Once API changes are implemented, this reliance on html parsing should be removed and the provenance attribute should be obtained through the API.