### PR TITLE
Implement Black 2023 style

### DIFF
--- a/app/public/cantusdata/helpers/expandr.py
+++ b/app/public/cantusdata/helpers/expandr.py
@@ -86,7 +86,6 @@ def expand_office(office_code):
 
 
 class PositionExpander(object):
-
     position_data_base = None
 
     def __init__(self):

--- a/app/public/cantusdata/helpers/mei_conversion/location_utils.py
+++ b/app/public/cantusdata/helpers/mei_conversion/location_utils.py
@@ -24,5 +24,5 @@ def getLocation(tokens):
 
 
 def getTokensBySystem(tokens):
-    for (_, group) in groupby(tokens, lambda tok: tok.system):
+    for _, group in groupby(tokens, lambda tok: tok.system):
         yield list(group)

--- a/app/public/cantusdata/helpers/mei_conversion/pitch_utils.py
+++ b/app/public/cantusdata/helpers/mei_conversion/pitch_utils.py
@@ -14,7 +14,7 @@ def getIntervals(semitones, pnames):
     tritones, they may use the semitones field.
     """
     intervals = []
-    for (interval, pname) in zip(semitones, pnames):
+    for interval, pname in zip(semitones, pnames):
         if interval == 0:
             intervals.append("r")
         else:

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -125,7 +125,8 @@ class SourceImporter:
             source_dict["date"] = source_json["field_date"]["und"][0]["value"]
         else:
             source_dict["date"] = ""
-        ## See documentation for
+        ## See documentation of the download_source_provenance method for details
+        ## on these commented lines.
         # if source_json["field_provenance"]:
         #     source_dict["provenance"] = source_json["field_provenance"]["und"][0]["value"]
         # else:

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -2,17 +2,19 @@ from urllib import request
 import json
 from html.parser import HTMLParser
 
+
 class ProvenanceParser(HTMLParser):
     """
     ProvenanceParser extracts the short provenance name from a CantusDB source
-    page (/source/id-of-source/). 
-    
-    provenance_div flags whether the parser has reached the div containing the 
+    page (/source/id-of-source/).
+
+    provenance_div flags whether the parser has reached the div containing the
     provenance text.
-    
-    provenance_a flags whether the parser has reached the anchor tag that contains 
+
+    provenance_a flags whether the parser has reached the anchor tag that contains
     the provenance text.
     """
+
     def __init__(self):
         super().__init__()
         self.provenance_div = False
@@ -25,11 +27,11 @@ class ProvenanceParser(HTMLParser):
         1. determine whether a div tag encountered by the parser has the unique
         class attributes assigned to the div that contains provenance data. If
         this div is encountered, the provenance_div flag is set to True.
-        2. if a anchor tag is encountered within this div tag, set the 
+        2. if a anchor tag is encountered within this div tag, set the
         provenance_a flag to True.
         """
         if tag == "div":
-            if ("class","views-field views-field-field-provenance-tax") in attrs:
+            if ("class", "views-field views-field-field-provenance-tax") in attrs:
                 self.provenance_div = True
         if tag == "a":
             if self.provenance_div:
@@ -42,7 +44,7 @@ class ProvenanceParser(HTMLParser):
         if self.provenance_a:
             self.provenance_div = False
             self.provenance_a = False
-    
+
     def handle_data(self, data):
         """
         Extract the provenance data when provenance_a has been triggered.
@@ -50,19 +52,21 @@ class ProvenanceParser(HTMLParser):
         if self.provenance_a:
             self.provenance = data
 
+
 class SourceImporter:
     """
     Imports sources from CantusDB by way of its APIs.
 
     :param str cantus_db_base_url: the domain for CantusDB.
     """
+
     def __init__(self, cantus_db_base_url):
         self.cdb_base_url = cantus_db_base_url
 
     def request_source_ids(self):
         """
         Requests the IDs of all sources available in CantusDB
-        
+
         :return: a list of character source ID's
         """
         sources_url = f"{self.cdb_base_url}/json-sources/"
@@ -75,7 +79,7 @@ class SourceImporter:
         """
         Requests data on an individual source in CantusDB using
         the /json-node/ endpoint.
-        
+
         :param str source_id: the ID of the source in CantusDB
         :return: a parsed json object containing source data
         """
@@ -83,7 +87,7 @@ class SourceImporter:
         source_response = request.urlopen(source_url).read()
         source_json = json.loads(source_response)
         return source_json
-    
+
     def download_source_provenance(self, source_id):
         """
         The current Old CantusDB API endpoints do not provide
@@ -92,7 +96,7 @@ class SourceImporter:
         on the source provenance, but not the shorter designation that is
         displayed publicly in CantusDB and on Cantus Ultimus). As such, this
         method extracts this source provenance from CantusDB html. Incorporating
-        this into CantusDB's API is an open issue 
+        this into CantusDB's API is an open issue
         (see https://github.com/DDMAL/CantusDB/issues/564), so this will be
         simplified once that is complete.
         """
@@ -121,7 +125,7 @@ class SourceImporter:
             source_dict["date"] = source_json["field_date"]["und"][0]["value"]
         else:
             source_dict["date"] = ""
-        ## See documentation for 
+        ## See documentation for
         # if source_json["field_provenance"]:
         #     source_dict["provenance"] = source_json["field_provenance"]["und"][0]["value"]
         # else:
@@ -132,11 +136,11 @@ class SourceImporter:
         else:
             source_dict["description"] = ""
         return source_dict
-            
+
     def get_source_data(self, source_id):
         """
-        Given a source ID from CantusDB, returns a dictionary of 
-        source metadata required to create a Cantus Ultimus 
+        Given a source ID from CantusDB, returns a dictionary of
+        source metadata required to create a Cantus Ultimus
         manuscript object.
 
         :param str source_id: the ID of the source in CantusDB

--- a/app/public/cantusdata/management/commands/generate_public_datadump.py
+++ b/app/public/cantusdata/management/commands/generate_public_datadump.py
@@ -4,7 +4,6 @@ import csv
 
 
 class Command(BaseCommand):
-
     CSV_PATH = "data_dumps/public-manuscripts.csv"
 
     help = (

--- a/app/public/cantusdata/management/commands/import_data.py
+++ b/app/public/cantusdata/management/commands/import_data.py
@@ -115,9 +115,7 @@ class Command(BaseCommand):
                     self.stdout.write(f"FORBIDDEN: {source_id}")
                 else:
                     self.stdout.write(f"FAILED: {source_id}")
-        self.stdout.write(
-            f"Successfully imported {i} manuscripts into database."
-        )
+        self.stdout.write(f"Successfully imported {i} manuscripts into database.")
 
     @transaction.atomic
     def import_concordance_data(self, **options):

--- a/app/public/cantusdata/management/commands/import_folio_mapping.py
+++ b/app/public/cantusdata/management/commands/import_folio_mapping.py
@@ -54,7 +54,6 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, *args, **options):
-
         manuscript_ids = options["manuscript_ids"]
         manuscript_mapping_dict = dict(zip(manuscript_ids, options["mapping_data"]))
         task = options.get("task", None)

--- a/app/public/cantusdata/management/commands/refresh_solr.py
+++ b/app/public/cantusdata/management/commands/refresh_solr.py
@@ -7,7 +7,6 @@ import solr
 
 
 class Command(BaseCommand):
-
     TYPE_MAPPING = {
         "manuscripts": Manuscript,
         "chants": Chant,

--- a/app/public/cantusdata/models/manuscript.py
+++ b/app/public/cantusdata/models/manuscript.py
@@ -28,7 +28,7 @@ class Manuscript(models.Model):
             )
         ]
 
-    id = models.IntegerField(primary_key = True)
+    id = models.IntegerField(primary_key=True)
     name = models.CharField(max_length=255, blank=True, null=True)
     siglum = models.CharField(max_length=255, blank=True, null=True)
     date = models.CharField(max_length=50, blank=True, null=True)

--- a/app/public/cantusdata/signals/solr_sync.py
+++ b/app/public/cantusdata/signals/solr_sync.py
@@ -36,13 +36,13 @@ class SolrSynchronizer(object):
             (Chant, post_delete, self.chant_deleted),
         ]
 
-        for (model, signal, receiver) in handlers:
+        for model, signal, receiver in handlers:
             signal.connect(receiver, sender=model)
 
         return handlers
 
     def detach_handlers(self):
-        for (model, signal, receiver) in self._handlers:
+        for model, signal, receiver in self._handlers:
             signal.disconnect(receiver, sender=model)
 
     @contextlib.contextmanager

--- a/app/public/cantusdata/test/core/helpers/test_expandr.py
+++ b/app/public/cantusdata/test/core/helpers/test_expandr.py
@@ -83,7 +83,6 @@ class ExpandrFunctionsTestCase(TestCase):
 
 
 class PositionExpanderTestCase(TestCase):
-
     position_expander = None
 
     def setUp(self):

--- a/app/public/cantusdata/test/core/views/test_chant.py
+++ b/app/public/cantusdata/test/core/views/test_chant.py
@@ -7,7 +7,6 @@ from cantusdata.models import Manuscript, Folio, Chant, Concordance
 
 
 class ChantViewTestCase(APITransactionTestCase):
-
     fixtures = ["1_users", "2_initial_data"]
 
     def setUp(self):

--- a/app/public/cantusdata/test/core/views/test_concordance.py
+++ b/app/public/cantusdata/test/core/views/test_concordance.py
@@ -7,7 +7,6 @@ from cantusdata.models import Concordance, Chant, Folio, Manuscript
 
 
 class ConcordanceViewTestCase(APITransactionTestCase):
-
     fixtures = ["1_users", "2_initial_data"]
 
     def setUp(self):

--- a/app/public/cantusdata/test/core/views/test_folio.py
+++ b/app/public/cantusdata/test/core/views/test_folio.py
@@ -7,7 +7,6 @@ from cantusdata.models import Folio, Chant, Manuscript
 
 
 class FolioViewTestCase(APITransactionTestCase):
-
     fixtures = ["1_users", "2_initial_data"]
 
     def setUp(self):

--- a/app/public/cantusdata/test/core/views/test_folio_set.py
+++ b/app/public/cantusdata/test/core/views/test_folio_set.py
@@ -3,7 +3,6 @@ from rest_framework import status
 
 
 class ManuscriptFolioSetViewTestCase(APITransactionTestCase):
-
     fixtures = ["1_users", "2_initial_data"]
 
     def setUp(self):

--- a/app/public/cantusdata/test/core/views/test_manuscript.py
+++ b/app/public/cantusdata/test/core/views/test_manuscript.py
@@ -7,7 +7,6 @@ from cantusdata.models import Manuscript, Folio, Chant, Concordance
 
 
 class ManuscriptViewTestCase(APITransactionTestCase):
-
     fixtures = ["1_users", "2_initial_data"]
 
     def setUp(self):

--- a/app/public/cantusdata/test/core/views/test_search.py
+++ b/app/public/cantusdata/test/core/views/test_search.py
@@ -6,7 +6,6 @@ from cantusdata.models import Chant, Folio, Manuscript, Concordance
 
 
 class MainViewTestCase(APITransactionTestCase):
-
     fixtures = ["1_users", "2_initial_data"]
 
     def setUp(self):

--- a/app/public/cantusdata/test/external/iiif/test_iiif.py
+++ b/app/public/cantusdata/test/external/iiif/test_iiif.py
@@ -101,7 +101,7 @@ class IIIFTestCase(TestCase):
                     {"region": "full", "size": ",160"},
                 ]
 
-                for (j, t) in enumerate(transformations):
+                for j, t in enumerate(transformations):
                     start = time.time()
                     req = f"{uri}/{t['region']}/{t['size']}/0/{path_tail}"
                     requests.get(req)

--- a/app/public/cantusdata/views/search_notation.py
+++ b/app/public/cantusdata/views/search_notation.py
@@ -22,7 +22,6 @@ class SearchNotationView(APIView):
     """
 
     def get(self, request, *args, **kwargs):
-
         q = request.GET.get("q", None)
         stype = request.GET.get("type", None)
         manuscript = request.GET.get("manuscript", None)

--- a/app/public/cantusdata/views/suggestion.py
+++ b/app/public/cantusdata/views/suggestion.py
@@ -7,7 +7,6 @@ import solr
 
 class SuggestionView(APIView):
     def get(self, request, *args, **kwargs):
-
         if not ("q" in request.GET and "dictionary" in request.GET):
             return Response()
 
@@ -35,7 +34,6 @@ class SuggestionView(APIView):
     def _get_filtered_results(self, suggestions):
         results = []
         for suggestion in suggestions:
-
             unique = True
 
             for result in results:


### PR DESCRIPTION
Reformats python files to adhere to Black's 2023 stable style. Most of the changes resulting from the style guide update involve removing empty lines and extra parentheses. Some reformatting also occurred on files merged while the repo's formatting test was failing.

This PR also includes a commit that expands on an erroneously truncated comment in the SourceImporter class that I discovered while reviewing Black's reformatting. 

Closes #673.