### PR TITLE
Modify open chant state management

### DIFF
--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/FolioView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/FolioView.js
@@ -76,7 +76,6 @@ export default Marionette.LayoutView.extend({
         manuscriptChannel.request('set:folio', this.model.get('number'), {replaceState: true});
         folioChannel.trigger('folioLoaded');
         this.chantCollection.reset();
-        manuscriptChannel.request('set:chant', null);
         this.assignChants();
     },
 

--- a/nginx/public/node/frontend/public/js/app/objects/OpenChantState.js
+++ b/nginx/public/node/frontend/public/js/app/objects/OpenChantState.js
@@ -84,14 +84,14 @@ export default Marionette.Object.extend({
      */
     persist: function (manuscript)
     {
-        if (window.localStorage)
+        if (window.sessionStorage)
         {
-            var key = this.getLocalStorageKey(manuscript);
+            var key = this.getSessionStorageKey(manuscript);
             var data = JSON.stringify(this.manuscripts[manuscript]);
 
             try
             {
-                window.localStorage.setItem(key, data);
+                window.sessionStorage.setItem(key, data);
             }
             catch (e)
             {
@@ -115,15 +115,15 @@ export default Marionette.Object.extend({
             return false;
         }
 
-        // Try to load the data from localStorage
-        if (window.localStorage)
+        // Try to load the data from sessionStorage
+        if (window.sessionStorage)
         {
-            var key = this.getLocalStorageKey(manuscript);
+            var key = this.getSessionStorageKey(manuscript);
             var data;
 
             try
             {
-                data = window.localStorage.getItem(key);
+                data = window.sessionStorage.getItem(key);
             }
             catch (e)
             {
@@ -156,7 +156,7 @@ export default Marionette.Object.extend({
         return true;
     },
 
-    getLocalStorageKey: function(manuscript)
+    getSessionStorageKey: function(manuscript)
     {
         return 'openChants:' + manuscript;
     }

--- a/nginx/public/node/frontend/public/js/app/objects/OpenChantState.js
+++ b/nginx/public/node/frontend/public/js/app/objects/OpenChantState.js
@@ -1,6 +1,23 @@
 import _ from 'underscore';
 import Marionette from 'marionette';
 
+/**
+ * NOTE: The OpenChantState object stores the state of chants
+ * for a particular manuscript in sessionStorage. Chant states
+ * are reset in new sessions (eg. new tabs or upon navigating
+ * away from the detail view of a particular manuscript). While 
+ * this has been implemented as a default so that chant do not
+ * "remain open" across visits some time apart, a future feature
+ * could allow users to decide whether or not chant states should
+ * reset or persist across multiple sessions and windows (ie. whether
+ * sessionStorage or localStorage should be used). When this feature
+ * is implemented logic in the various methods of this object ("persist",
+ * "ensureCreated") should be added to read and write chant states
+ * to sessionStorage or localStorage based on user preferences, rather
+ * than to sessionStorage only.
+ */
+
+
 export default Marionette.Object.extend({
     initialize: function ()
     {
@@ -84,7 +101,7 @@ export default Marionette.Object.extend({
      */
     persist: function (manuscript)
     {
-        if (window.sessionStorage)
+        if (window.sessionStorage) 
         {
             var key = this.getSessionStorageKey(manuscript);
             var data = JSON.stringify(this.manuscripts[manuscript]);


### PR DESCRIPTION
This PR changes behaviour of chant panes on the manuscript detail page:

1. When a `chant` parameter is set in a url (eg. `/manuscript/25/?folio[0]=008v&chant=5`), the detail panel for this chant is opened on page load. This allows users to copy and share a url to a specific chant. Closes #653. This reverses the change in #623, which was setting the open chant to `null` and overriding the `chant` parameter in the url.
2. Changes where the state (open/closed) of chants for a  manuscript is saved. Previously, this state was stored in `localStorage`, which maintained these states across multiple browser sessions. This led to multiple chants being open on return visits to a manuscript without a clear reason (see #619; in fact, those chants had just been opened but not closed on previous visits). This PR causes these states to be stored in `sessionStorage`, which maintains these states in a single tab across page reloads, but flushes states across multiple tabs and new sessions. In effect, chants are "kept open" while scrolling between folios for the short term, but are "re-set" in the longer term or in new tabs.

Per @fujinaga: eventually, the decision of how long/extensively to save open chants for a manuscript (ie. within sessions/tabs or across sessions/tabs) should be made by the user. Comments in `OpenChangeState.js` are added to bring this to the attention of other developers. 

