### PR TITLE
Escape hyphens in volpiano (literal) searches

### DIFF
--- a/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
@@ -96,6 +96,8 @@ export default Marionette.Object.extend({
 
     getSearchMetadata: function ()
     {
+        // Modify query returned by solr so it is ready for display.
+        // Remove escaping backslashes from the displayed string.
         let query = this.searchParameters.get('query');
         let displayedQuery = query.replaceAll("\\-", "-");
         return {

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
@@ -96,10 +96,13 @@ export default Marionette.Object.extend({
 
     getSearchMetadata: function ()
     {
+        let query = this.searchParameters.get('query');
+        let displayedQuery = query.replaceAll("\\-", "-");
         return {
             fieldName: this.searchParameters.get('field'),
-            query: this.searchParameters.get('query'),
-            numFound: this.collection.metadata.numFound
+            query: query,
+            numFound: this.collection.metadata.numFound,
+            displayedQuery: displayedQuery
         };
     },
 

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/SearchInputView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/SearchInputView.js
@@ -51,13 +51,19 @@ export default Marionette.ItemView.extend({
         var searchField = this.model.get('field');
         var searchInput = this.ui.searchInput.val();
         if (searchField === 'volpiano' || searchField === 'volpiano_literal'){
+            // Ensure that search input field displays a treble clef as the default
+            // search value, and replace it if user deletes it.
             if (searchInput == "" || searchInput == "1"){
                 this.ui.searchInput.val("1-");
                 searchInput = "1-";
             }
             searchInput = searchInput.replaceAll(this.invalidVolpianoRegex, "")
             this.ui.searchInput.val(searchInput)
+            // Remove the treble clef before the string is sent to solr. Volpiano
+            // searches assume treble clef.
             searchInput = searchInput.replaceAll("1-","");
+            // Replace hyphens (a reserved character in solr queries) with 
+            // escaped hyphens in the query string.
             searchInput = searchInput.replaceAll("-","\\-");
         }
         // FIXME(wabain): While this class needs to take a SearchInput model so it can initially

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/SearchInputView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/SearchInputView.js
@@ -58,6 +58,7 @@ export default Marionette.ItemView.extend({
             searchInput = searchInput.replaceAll(this.invalidVolpianoRegex, "")
             this.ui.searchInput.val(searchInput)
             searchInput = searchInput.replaceAll("1-","");
+            searchInput = searchInput.replaceAll("-","\\-");
         }
         // FIXME(wabain): While this class needs to take a SearchInput model so it can initially
         // be rendered, we're not actually updating that model here - we're just triggering

--- a/nginx/public/node/frontend/public/js/app/search/search-result-heading.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/search-result-heading.template.html
@@ -1,6 +1,6 @@
 <p class="h4"><i><%- numFound %> <%- numFound === 1 ? 'result' : 'results' %> for query 
 <% if (fieldName == "volpiano" || fieldName == "volpiano_literal") { %>
-</i><span class = "volpiano">1-<%- query %></span>
+</i><span class = "volpiano">1-<%- displayedQuery %></span>
 <% } else { %>
 "<%- query %>"</i>
 <% } %>

--- a/solr/solr/collection1/conf/schema.xml
+++ b/solr/solr/collection1/conf/schema.xml
@@ -358,12 +358,12 @@
     <fieldType name="volpiano_general" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
             <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ExtractVolpianoNotes.txt" />
-            <filter class="solr.PatternReplaceFilterFactory" pattern="-" replacement="" />
-            <tokenizer class="solr.NGramTokenizerFactory" minGramSize="2" maxGramSize="50" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="-" replacement="" />
+            <tokenizer class="solr.NGramTokenizerFactory" minGramSize="1" maxGramSize="50" />
         </analyzer>
         <analyzer type="query">
             <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ExtractVolpianoNotes.txt" />
-            <filter class="solr.PatternReplaceFilterFactory" pattern="-" replacement="" />
+            <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="-" replacement="" />
             <tokenizer class="solr.KeywordTokenizerFactory" />
         </analyzer>
     </fieldType>
@@ -371,7 +371,7 @@
     <fieldType name="volpiano_literal" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
             <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ExtractVolpianoNotes.txt" />
-            <tokenizer class="solr.NGramTokenizerFactory" minGramSize="2" maxGramSize="50" />
+            <tokenizer class="solr.NGramTokenizerFactory" minGramSize="1" maxGramSize="50" />
         </analyzer>
         <analyzer type="query">
             <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-ExtractVolpianoNotes.txt" />


### PR DESCRIPTION
Fixes #687 and fixes #689. 

Hyphens are a reserved character in solr's query language as the boolean "prohibit" operator (https://solr.apache.org/guide/6_6/the-standard-query-parser.html#TheStandardQueryParser-TheBooleanOperator-). This doesn't work so well with the logic of `Volpiano (Literal)` searches, where hyphens will be included in the search string to differentiate between neumes, syllables, and words. 

This PR modifies a volpiano query by escaping hyphens in the query string before sending the query to the solr query parser. These escape characters are then removed again before the query is displayed as part of the query results. 

The PR also adjusts the filters and tokenizers in the solr schema to allow for single-character volpiano queries. Because of the way tokenizing and filtering had been configured previously, `Volpiano` searches would return results to single-character queries while `Volpiano (Literal)` searches would not. 