### PR TITLE
Modify concordance import process and clean import_data commant

### DIFF
--- a/app/public/cantusdata/helpers/scrapers/concordances.py
+++ b/app/public/cantusdata/helpers/scrapers/concordances.py
@@ -3,6 +3,12 @@ import urllib.request
 import sys
 import re
 
+# April 2023: In order to harmonize the process of importing concordances 
+# with that of other static data (ie. iiif manifests), concordances are now
+# stored in data_dumps/concordances.csv and loaded directly in the 
+# import_concordance_data function in the import_data command.
+# This file is retained for reference.
+
 """The CAO concordances used to be scraped from the Cantus Website.
 
 However, as of July 2020, this information is no longer on the website.

--- a/app/public/cantusdata/helpers/scrapers/concordances.py
+++ b/app/public/cantusdata/helpers/scrapers/concordances.py
@@ -3,9 +3,9 @@ import urllib.request
 import sys
 import re
 
-# April 2023: In order to harmonize the process of importing concordances 
+# April 2023: In order to harmonize the process of importing concordances
 # with that of other static data (ie. iiif manifests), concordances are now
-# stored in data_dumps/concordances.csv and loaded directly in the 
+# stored in data_dumps/concordances.csv and loaded directly in the
 # import_concordance_data function in the import_data command.
 # This file is retained for reference.
 

--- a/app/public/cantusdata/management/commands/import_data.py
+++ b/app/public/cantusdata/management/commands/import_data.py
@@ -123,7 +123,9 @@ class Command(BaseCommand):
         creates a Concordance object in the database for each
         concordance.
         """
-        with open(f"{BASE_DIR}/data_dumps/concordances.csv", "r", encoding="utf-8") as file:
+        with open(
+            f"{BASE_DIR}/data_dumps/concordances.csv", "r", encoding="utf-8"
+        ) as file:
             concord_reader = csv.DictReader(file)
             concord_counter = 0
             for c in concord_reader:
@@ -154,18 +156,18 @@ class Command(BaseCommand):
             chant_count = importer.import_csv(fcsv)
         # Save the new chants
         importer.save(task=task)
-        self.stdout.write(
-            f"Successfully imported {chant_count} chants into database."
-        )
+        self.stdout.write(f"Successfully imported {chant_count} chants into database.")
 
     @transaction.atomic
     def import_iiif_data(self):
-        with open(f"{BASE_DIR}/data_dumps/manifests.csv", "r", encoding ='utf-8') as file:
+        with open(
+            f"{BASE_DIR}/data_dumps/manifests.csv", "r", encoding="utf-8"
+        ) as file:
             iiif_reader = csv.DictReader(file)
 
             for row in iiif_reader:
-                siglum = row['siglum']
-                manifest_url = row['manifest_url']
+                siglum = row["siglum"]
+                manifest_url = row["manifest_url"]
                 qs = Manuscript.objects.filter(siglum=siglum)
                 if len(qs) > 0:
                     mobj = qs[0]

--- a/app/public/cantusdata/management/commands/import_data.py
+++ b/app/public/cantusdata/management/commands/import_data.py
@@ -127,7 +127,7 @@ class Command(BaseCommand):
             f"{BASE_DIR}/data_dumps/concordances.csv", "r", encoding="utf-8"
         ) as file:
             concord_reader = csv.DictReader(file)
-            concord_counter = 0
+            concord_count = 0
             for c in concord_reader:
                 concordance = Concordance()
                 concordance.letter_code = c["letter_code"]
@@ -138,9 +138,9 @@ class Command(BaseCommand):
                 concordance.location = c["location"]
                 concordance.rism_code = c["rism_code"]
                 concordance.save()
-                concord_counter += 1
+                concord_count += 1
         self.stdout.write(
-            f"Successfully imported {concord_counter} concordances into database."
+            f"Successfully imported {concord_count} concordances into database."
         )
 
     def import_chant_data(self, **options):

--- a/app/public/cantusdata/management/commands/import_data.py
+++ b/app/public/cantusdata/management/commands/import_data.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         with solr_synchronizer.get_session():
-            self.stdout.write("Deleting old {0} data...".format(options["type"]))
+            self.stdout.write(f"Deleting old {options['type']} data...")
             task = options.get("task", None)
             if options["type"] == "chants":
                 # manuscript-id is not optional for chants
@@ -155,18 +155,19 @@ class Command(BaseCommand):
         # Save the new chants
         importer.save(task=task)
         self.stdout.write(
-            "Successfully imported {} chants into database.".format(chant_count)
+            f"Successfully imported {chant_count} chants into database."
         )
 
     @transaction.atomic
     def import_iiif_data(self):
-        with open(path.join(BASE_DIR, "data_dumps", "manifests.csv"), "r") as file:
-            csv = file.readlines()
+        with open(f"{BASE_DIR}/data_dumps/manifests.csv", "r", encoding ='utf-8') as file:
+            iiif_reader = csv.DictReader(file)
 
-        for row in csv:
-            siglum, manifest_url = row.strip().rsplit(",", 1)
-            qs = Manuscript.objects.filter(siglum=siglum)
-            if len(qs) > 0:
-                mobj = qs[0]
-                mobj.manifest_url = manifest_url
-                mobj.save()
+            for row in iiif_reader:
+                siglum = row['siglum']
+                manifest_url = row['manifest_url']
+                qs = Manuscript.objects.filter(siglum=siglum)
+                if len(qs) > 0:
+                    mobj = qs[0]
+                    mobj.manifest_url = manifest_url
+                    mobj.save()

--- a/app/public/data_dumps/concordances.csv
+++ b/app/public/data_dumps/concordances.csv
@@ -1,13 +1,13 @@
-letter_code, institution_city, institution_name, library_manuscript_name, date, location, rism_code
-C, Paris, Bibliothèque nationale de France, lat. 17436, ninth century, Compiègne, F-Pn lat. 17436
-G, Durham, Cathedral Library, B. III. 11, eleventh century, northern France, GB-DRc B. III. 11
-B, Bamberg, Staatsbibliothek, lit. 23, eleventh or twelfth century, Bamberg, D-BAs lit. 23
-E, Ivrea, Biblioteca Capitolare, 106, eleventh century, Ivrea, I-IV 106
-M, Monza, Basilica di S. Giovanni Battista - Biblioteca Capitolare e Tesoro, C. 12/75, eleventh century, Monza, I-MZ C. 12/75
-V, Verona, Biblioteca Capitolare, XCVIII, eleventh century, Verona, I-VEcap XCVIII
-H, Sankt Gallen, Stiftsbibliothek, 390-391 (“Hartker antiphoner”), early eleventh century, St. Gall, CH-SGs 390-391
-R, Zürich, Zentralbibliothek, Rh. 28, thirteenth century, Rheinau, CH-Zz Rh. 28
-D, Paris, Bibliothèque nationale de France, lat. 17296, twelfth century, St. Denis, F-Pn lat. 17296
-F, Paris, Bibliothèque nationale de France, lat. 12584, twelfth century, St. Maur-les-Fossés, F-Pn lat. 12584
-S, London, The British Library, add. 30850, eleventh century, Silos, GB-Lbl add. 30850
-L, Benevento, Biblioteca Capitolare, V 21, late twelfth century, San Lupo, I-BV V. 21
+letter_code,institution_city,institution_name,library_manuscript_name,date,location,rism_code
+C,Paris,Bibliothèque nationale de France,lat. 17436,ninth century,Compiègne,F-Pn lat. 17436
+G,Durham,Cathedral Library,B. III. 11,eleventh century,northern France,GB-DRc B. III. 11
+B,Bamberg,Staatsbibliothek,lit. 23,eleventh or twelfth century,Bamberg,D-BAs lit. 23
+E,Ivrea,Biblioteca Capitolare,106,eleventh century,Ivrea,I-IV 106
+M,Monza,Basilica di S. Giovanni Battista - Biblioteca Capitolare e Tesoro,C. 12/75,eleventh century,Monza,I-MZ C. 12/75
+V,Verona,Biblioteca Capitolare,XCVIII,eleventh century,Verona,I-VEcap XCVIII
+H,Sankt Gallen,Stiftsbibliothek,390-391 (“Hartker antiphoner”),early eleventh century,St. Gall,CH-SGs 390-391
+R,Zürich,Zentralbibliothek,Rh. 28,thirteenth century,Rheinau,CH-Zz Rh. 28
+D,Paris,Bibliothèque nationale de France,lat. 17296,twelfth century,St. Denis,F-Pn lat. 17296
+F,Paris,Bibliothèque nationale de France,lat. 12584,twelfth century,St. Maur-les-Fossés,F-Pn lat. 12584
+S,London,The British Library,add. 30850,eleventh century,Silos,GB-Lbl add. 30850
+L,Benevento,Biblioteca Capitolare,V 21,late twelfth century,San Lupo,I-BV V. 21

--- a/app/public/data_dumps/concordances.csv
+++ b/app/public/data_dumps/concordances.csv
@@ -1,3 +1,4 @@
+letter_code, institution_city, institution_name, library_manuscript_name, date, location, rism_code
 C, Paris, Bibliothèque nationale de France, lat. 17436, ninth century, Compiègne, F-Pn lat. 17436
 G, Durham, Cathedral Library, B. III. 11, eleventh century, northern France, GB-DRc B. III. 11
 B, Bamberg, Staatsbibliothek, lit. 23, eleventh or twelfth century, Bamberg, D-BAs lit. 23

--- a/app/public/data_dumps/concordances.csv
+++ b/app/public/data_dumps/concordances.csv
@@ -1,0 +1,12 @@
+C, Paris, Bibliothèque nationale de France, lat. 17436, ninth century, Compiègne, F-Pn lat. 17436
+G, Durham, Cathedral Library, B. III. 11, eleventh century, northern France, GB-DRc B. III. 11
+B, Bamberg, Staatsbibliothek, lit. 23, eleventh or twelfth century, Bamberg, D-BAs lit. 23
+E, Ivrea, Biblioteca Capitolare, 106, eleventh century, Ivrea, I-IV 106
+M, Monza, Basilica di S. Giovanni Battista - Biblioteca Capitolare e Tesoro, C. 12/75, eleventh century, Monza, I-MZ C. 12/75
+V, Verona, Biblioteca Capitolare, XCVIII, eleventh century, Verona, I-VEcap XCVIII
+H, Sankt Gallen, Stiftsbibliothek, 390-391 (“Hartker antiphoner”), early eleventh century, St. Gall, CH-SGs 390-391
+R, Zürich, Zentralbibliothek, Rh. 28, thirteenth century, Rheinau, CH-Zz Rh. 28
+D, Paris, Bibliothèque nationale de France, lat. 17296, twelfth century, St. Denis, F-Pn lat. 17296
+F, Paris, Bibliothèque nationale de France, lat. 12584, twelfth century, St. Maur-les-Fossés, F-Pn lat. 12584
+S, London, The British Library, add. 30850, eleventh century, Silos, GB-Lbl add. 30850
+L, Benevento, Biblioteca Capitolare, V 21, late twelfth century, San Lupo, I-BV V. 21

--- a/app/public/data_dumps/manifests.csv
+++ b/app/public/data_dumps/manifests.csv
@@ -1,3 +1,4 @@
+siglum,manifest_url
 A-KN 1010,https://manuscripta.at/diglit/iiif/AT5000-1010/manifest.json
 A-KN 1011,https://manuscripta.at/diglit/iiif/AT5000-1011/manifest.json
 A-KN 1012,https://manuscripta.at/diglit/iiif/AT5000-1012/manifest.json


### PR DESCRIPTION
Fixes #678 by importing concordance data from a csv file in `data_dumps`. 

Also makes some adjustments for general code cleanliness in the `import_data` command (eg. using f-strings, removing unused imports, and using python's built-in csv reader for reading csv files.