### PR TITLE
Fix map folios backup processes

### DIFF
--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -159,8 +159,13 @@
     {% csrf_token %}
     <input type="hidden" name="manuscript_id" value="{{ manuscript_id }}" />
     <div class="two-folio-checkbox">
+        {% if not dbl_folio_img %}
             <input type="checkbox" id="two-folio-images" name="two_folio_images"
                    unchecked>
+        {% else %}
+            <input type="checkbox" id="two-folio-images" name="two_folio_images"
+                checked>
+        {% endif %}
             <label for="two-folio-images">Images have two folios?</label>
     </div>
     <ul>
@@ -169,12 +174,26 @@
         <li>
             <a href={{ uri.large }} target="_blank"><img src={{ uri.thumbnail }} /></a>
             {{ uri.id }}
-            {% if uri.folio %}
-            <input type="text" class="folio-mapping single-folio-inputs" name={{ uri.full }} onchange="checkMappedFolios()" value={{ uri.folio }} />
+            {% if not dbl_folio_img %}
+                {% if uri.folio %}
+                    <input type="text" class="folio-mapping first-folio-input" name={{ uri.full }} onchange="checkMappedFolios()" value={{ uri.folio.0 }} />
+                {% else %}
+                    <input type="text" class="folio-mapping first-folio-input" name={{ uri.full }} onchange="checkMappedFolios()"/>
+                {% endif %}
+                <input hidden type="text" class="folio-mapping second-folio-input" name={{ uri.full }} onchange="checkMappedFolios()" />      
             {% else %}
-            <input type="text" class="folio-mapping single-folio-inputs" name={{ uri.full }} onchange="checkMappedFolios()"/>
+                {% if uri.folio %}
+                    <input type="text" class="folio-mapping first-folio-input" name={{ uri.full }} onchange="checkMappedFolios()" value={{ uri.folio.0 }} />
+                    {% if uri.folio.1 %}
+                        <input type="text" class="folio-mapping second-folio-input" name={{ uri.full }} onchange="checkMappedFolios()" value={{ uri.folio.1 }} />
+                    {% else %}
+                        <input type="text" class="folio-mapping second-folio-input" name={{ uri.full }} onchange="checkMappedFolios()" />
+                    {% endif %}
+                {% else %}
+                    <input type="text" class="folio-mapping first-folio-input" name={{ uri.full }} onchange="checkMappedFolios()"/>
+                    <input type="text" class="folio-mapping second-folio-input" name={{ uri.full }} onchange="checkMappedFolios()"/>
+                {% endif %}
             {% endif %}
-            <input hidden type="text" class="folio-mapping double-folio-inputs" name={{ uri.full }} onchange="checkMappedFolios()" />      
             <div class="button" onclick="onMoveUp({{ forloop.counter0 }})" tabindex="-1">Up</div>
             <div class="button" onclick="onMoveDown({{ forloop.counter0 }})" tabindex="-1">Down</div>
         </li>
@@ -204,8 +223,8 @@
 <script>
     var folios = document.getElementsByClassName('folio-name');
     var inputs = document.getElementsByClassName('folio-mapping');
-    var singleFolioInputs = document.getElementsByClassName('single-folio-inputs');
-    var doubleFolioInputs = document.getElementsByClassName('double-folio-inputs');
+    var singleFolioInputs = document.getElementsByClassName('first-folio-input');
+    var doubleFolioInputs = document.getElementsByClassName('second-folio-input');
     var visibleInputs = singleFolioInputs;
 
     document.body.addEventListener('dragover', handleDragOver, false);
@@ -217,16 +236,15 @@
     twoFolioBox.addEventListener('change', handleTwoFolioBoxChange);
 
     function handleTwoFolioBoxChange(evt){
-        for (var i = 0; i < doubleFolioInputs.length; i++){
-            if (doubleFolioInputs[i].hidden){
-                doubleFolioInputs[i].hidden = false;
-            } else {
-                doubleFolioInputs[i].hidden = true;
-            }
-        }
         if (twoFolioBox.checked){
+            for (var i = 0; i < doubleFolioInputs.length; i++){
+                doubleFolioInputs[i].hidden = false;
+            }
             visibleInputs = inputs;
         } else {
+            for (var i = 0; i < doubleFolioInputs.length; i++){
+                doubleFolioInputs[i].hidden = true;
+            }
             visibleInputs = singleFolioInputs;
         }
         indexDoubleFolioToggle();
@@ -250,6 +268,7 @@
 
         var file = evt.dataTransfer.files[0];
         loadBackup(file);
+        CheckMappedFolios();
     }
 
     function handleDragOver(evt) {
@@ -321,11 +340,11 @@
             for (var i = 1; i < lines.length; i++) {
                 var values = lines[i].split(',');
 
-                while (inputIndex < inputs.length && inputs[inputIndex].name !== values[1])
+                while (inputIndex < visibleInputs.length && visibleInputs[inputIndex].name !== values[1])
                     inputIndex++;
 
-                if (inputIndex < inputs.length)
-                    inputs[inputIndex].value = values[0];
+                if (inputIndex < visibleInputs.length)
+                    visibleInputs[inputIndex].value = values[0];
             }
         }
     }

--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -228,8 +228,8 @@
 <script>
     var folios = document.getElementsByClassName('folio-name');
     var inputs = document.getElementsByClassName('folio-mapping');
-    var singleFolioInputs = document.getElementsByClassName('first-folio-input');
-    var doubleFolioInputs = document.getElementsByClassName('second-folio-input');
+    var firstFolioInputs = document.getElementsByClassName('first-folio-input');
+    var secondFolioInputs = document.getElementsByClassName('second-folio-input');
 
     document.body.addEventListener('dragover', handleDragOver, false);
     document.body.addEventListener('drop', handleFileDrop, false);
@@ -245,20 +245,20 @@
     if (twoFolioBox.checked){
         var visibleInputs = inputs;
     } else {
-        var visibleInputs = singleFolioInputs;
+        var visibleInputs = firstFolioInputs;
     }
 
     function handleTwoFolioBoxChange(evt){
         if (twoFolioBox.checked){
-            for (var i = 0; i < doubleFolioInputs.length; i++){
-                doubleFolioInputs[i].hidden = false;
+            for (var i = 0; i < secondFolioInputs.length; i++){
+                secondFolioInputs[i].hidden = false;
             }
             visibleInputs = inputs;
         } else {
-            for (var i = 0; i < doubleFolioInputs.length; i++){
-                doubleFolioInputs[i].hidden = true;
+            for (var i = 0; i < secondFolioInputs.length; i++){
+                secondFolioInputs[i].hidden = true;
             }
-            visibleInputs = singleFolioInputs;
+            visibleInputs = firstFolioInputs;
         }
         indexDoubleFolioToggle();
         checkMappedFolios();
@@ -344,24 +344,30 @@
     }
 
     function loadBackup(file) {
+        // Read the backup csv file uploaded by the user.
         var reader = new FileReader();
         reader.readAsText(file, "UTF-8");
         reader.onload = function (e) {
+            // Split the lines of the csv.
             var lines = e.target.result.split('\n');
             var inputIndex = 0;
+            // Iterate through each line (folio, uri) of the 
+            // csv file and fill in the appropriate input field.
             for (var i = 1; i < lines.length; i++) {
                 let line = lines[i].replaceAll('\r','');
                 let values = line.split(',');
+                let folio = values[0];
+                let uri = values[1];
                 
                 // Iterate through visible inputs until the appropriate image uri
                 // is reached. In manuscripts with images with two folios (and
                 // therefore two input fields per image), the fields are filled in the
                 // order in which they occur in the backup file.
-                while (inputIndex < visibleInputs.length && visibleInputs[inputIndex].name !== values[1])
+                while (inputIndex < visibleInputs.length && visibleInputs[inputIndex].name !== uri)
                     inputIndex++;
 
                 if (inputIndex < visibleInputs.length)
-                    visibleInputs[inputIndex].value = values[0];
+                    visibleInputs[inputIndex].value = folio;
                     inputIndex++;
             }
             checkMappedFolios();

--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -303,16 +303,18 @@
 
     function onSaveBackup() {
         var data = 'folio,uri\n';
-        for (var i = 0, len = inputs.length; i < len; i++) {
-            data += inputs[i].value + ',' + inputs[i].name + '\n';
+        for (var i = 0, len = visibleInputs.length; i < len; i++) {
+            data += visibleInputs[i].value + ',' + visibleInputs[i].name + '\n';
         }
-        console.log(data);
-        download('backup.csv', data);
+        const loc = document.location;
+        const searchParams = new URLSearchParams(loc.search);
+        const manID = searchParams.get('manuscript_id');
+        download(`folio_mapping_backup_${manID}.csv`, data);
     }
 
     function loadBackup(file) {
         var reader = new FileReader();
-        reader.readAsText(file, "UTF-8");
+        reader.readAsText(file, "UTF-8");d
         reader.onload = function (e) {
             var lines = e.target.result.split('\n');
             var inputIndex = 0;

--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -225,7 +225,6 @@
     var inputs = document.getElementsByClassName('folio-mapping');
     var singleFolioInputs = document.getElementsByClassName('first-folio-input');
     var doubleFolioInputs = document.getElementsByClassName('second-folio-input');
-    var visibleInputs = singleFolioInputs;
 
     document.body.addEventListener('dragover', handleDragOver, false);
     document.body.addEventListener('drop', handleFileDrop, false);
@@ -234,6 +233,12 @@
 
     var twoFolioBox = document.getElementById('two-folio-images');
     twoFolioBox.addEventListener('change', handleTwoFolioBoxChange);
+
+    if (twoFolioBox.checked){
+        var visibleInputs = inputs;
+    } else {
+        var visibleInputs = singleFolioInputs;
+    }
 
     function handleTwoFolioBoxChange(evt){
         if (twoFolioBox.checked){

--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -170,6 +170,11 @@
     </div>
     <ul>
         <li><h4>Pages from the manifest:</h4></li>
+        <!-- Manuscripts are assumed by default to have only one folio per image. In this case, 
+            or if the manuscript has previously been mapped with only one folio per image,
+            the input boxes with second-folio-input are created hidden. If the manuscript has
+            previously been mapped with two folios per image, this mapping is shown intially (ie.
+            the second-folio-input boxes are visible). -->
         {% for uri in uris %}
         <li>
             <a href={{ uri.large }} target="_blank"><img src={{ uri.thumbnail }} /></a>
@@ -234,6 +239,9 @@
     var twoFolioBox = document.getElementById('two-folio-images');
     twoFolioBox.addEventListener('change', handleTwoFolioBoxChange);
 
+    // Set the visible inputs to the correct set
+    // of inputs based on whether the manuscript has
+    // images with two folios.
     if (twoFolioBox.checked){
         var visibleInputs = inputs;
     } else {
@@ -273,7 +281,6 @@
 
         var file = evt.dataTransfer.files[0];
         loadBackup(file);
-        CheckMappedFolios();
     }
 
     function handleDragOver(evt) {
@@ -343,14 +350,21 @@
             var lines = e.target.result.split('\n');
             var inputIndex = 0;
             for (var i = 1; i < lines.length; i++) {
-                var values = lines[i].split(',');
-
+                let line = lines[i].replaceAll('\r','');
+                let values = line.split(',');
+                
+                // Iterate through visible inputs until the appropriate image uri
+                // is reached. In manuscripts with images with two folios (and
+                // therefore two input fields per image), the fields are filled in the
+                // order in which they occur in the backup file.
                 while (inputIndex < visibleInputs.length && visibleInputs[inputIndex].name !== values[1])
                     inputIndex++;
 
                 if (inputIndex < visibleInputs.length)
                     visibleInputs[inputIndex].value = values[0];
+                    inputIndex++;
             }
+            checkMappedFolios();
         }
     }
 

--- a/app/public/cantusdata/templates/admin/map_folios.html
+++ b/app/public/cantusdata/templates/admin/map_folios.html
@@ -314,7 +314,7 @@
 
     function loadBackup(file) {
         var reader = new FileReader();
-        reader.readAsText(file, "UTF-8");d
+        reader.readAsText(file, "UTF-8");
         reader.onload = function (e) {
             var lines = e.target.result.split('\n');
             var inputIndex = 0;

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -16,8 +16,14 @@ class MapFoliosView(APIView):
     renderer_classes = (TemplateHTMLRenderer,)
 
     def get(self, request, *args, **kwargs):
-        # Return the URIs and folio names
-
+        """
+        A GET request to the map folios page can have two different states:
+        1. No manuscript_id is specified in the request. In this case, we display
+        a list of manuscripts and their mapping status.
+        2. A manuscript_id is specified in the request. In this case, the user
+        has specified a manuscript to map (or re-map). In this case, we display
+        the mapping tool.
+        """
         # If no manuscript specified,
         # display list of manuscripts and mapping status.
         if "manuscript_id" not in request.GET:
@@ -29,74 +35,47 @@ class MapFoliosView(APIView):
             return Response({"manuscript_ids": manuscript_ids})
 
         # If manuscript is specified, retrieve manuscript object
-        # from db.
+        # and that manuscripts folios from db.
         manuscript_id = int(request.GET["manuscript_id"])
         manuscript_obj = Manuscript.objects.get(id=manuscript_id)
-        manifest = manuscript_obj.manifest_url
-
-        # Get IIIF manifest from manifest link.
-        # Get individual URIs of manuscript.
-        uris_objs = []
-        uris = []
-
-        manifest_json = urllib.request.urlopen(manifest)
-        manifest_data = json.loads(manifest_json.read().decode("utf-8"))
-        for canvas in manifest_data["sequences"][0]["canvases"]:
-            service = canvas["images"][0]["resource"]["service"]
-            uri = service["@id"]
-            uris.append(uri)
-            path_tail = (
-                "default.jpg"
-                if service["@context"] == "http://iiif.io/api/image/2/context.json"
-                else "native.jpg"
-            )
-            uris_objs.append(
-                {
-                    "full": uri,
-                    "thumbnail": uri + "/full/,160/0/" + path_tail,
-                    "large": uri + "/full/,1800/0/" + path_tail,
-                    "short": re.sub(r"^.*/(?!$)", "", uri),
-                }
-            )
-        # Get unique ids in uri strings
-        uri_ids = _extract_ids(uris)
-        # Query db for folios associated with manuscript
-        folios_query = Folio.objects.filter(manuscript__id=manuscript_id)
-        folios = [f.number for f in folios_query]
+        folios_objs = Folio.objects.filter(manuscript__id=manuscript_id)
+        folios = [f.number for f in folios_objs]
         map_status = manuscript_obj.is_mapped
         dbl_folio_img = manuscript_obj.dbl_folio_img
+        manifest_url = manuscript_obj.manifest_url
 
-        # Create a dictionary mapping IDs extracted
-        # from the image_link field (where it exists)
-        # to folio numbers.
+        # Extract individual image uris and ids from the manifest.
+        uris, uris_objs = _extract_uris_from_manifest(manifest_url)
+        uri_ids = _extract_ids(uris)
+
+        # If the manuscript has not yet been mapped in Cantus Ultimus,
+        # we first check to see if a mapping between folios and images was
+        # imported alongside chant data from CantusDB (these would be
+        # stored in the "image_link" field of the folio object)
         if map_status == "UNMAPPED":
-            imagelinks = folios_query.values_list("number", "image_link")
-            imagelinks_ids = _extract_ids([i[1] for i in imagelinks if len(i[1]) > 0])
-            imagelink_folio = {
-                k: v for k, v in zip(imagelinks_ids, [i[0] for i in imagelinks])
-            }
+            imagelink_folio_map = _extract_imagelinks(folios_objs)
 
-        # Iterate through manifest uris.
+        # Iterate through all the image uris extracted from the manifest.
         # When a manuscript is already mapped,
         # map uris to folios based on the existing image_uri field.
         # Where not mapped, try to map uris to folios based on the
         # image_link field. If a manuscript is not mapped, and
-        # no image_link field exists, map uris to folios naively (first
-        # uri to first folio, etc.)
-        mapped_folios = 0
+        # the image_link field is empty or yields no mapping,
+        # map uris to folios naively (first uri to first folio, etc.)
+        any_previously_mapped_folios = False
         for idx, uri in enumerate(uris_objs):
             uri["id"] = uri_ids[idx]
             uri["folio"] = None
             if map_status == "MAPPED":
-                fols_w_uri = folios_query.filter(image_uri=uri["full"])
+                fols_w_uri = folios_objs.filter(image_uri=uri["full"])
                 uri["folio"] = [f.number for f in fols_w_uri]
-                mapped_folios += 1
+                any_previously_mapped_folios = True
             else:
-                if uri["id"] in imagelink_folio:
-                    uri["folio"] = [imagelink_folio[uri["id"]]]
-                    mapped_folios += 1
+                if uri["id"] in imagelink_folio_map:
+                    uri["folio"] = [imagelink_folio_map[uri["id"]]]
+                    any_previously_mapped_folios = True
 
-        if mapped_folios == 0 and len(uris_objs) >= len(folios):
+        if not any_previously_mapped_folios and len(uris_objs) >= len(folios):
             for idx, folio in enumerate(folios):
                 uris_objs[idx]["folio"] = [folio]
 
@@ -118,6 +97,49 @@ class MapFoliosView(APIView):
             return Response({"error": e})
 
         return HttpResponseRedirect("/admin/map_folios/")
+
+
+def _extract_uris_from_manifest(manifest_url):
+    """
+    Downloads the IIIF manifest from the provided url and extracts
+    the uris for individual images in the manuscript.
+    Returns a list of these uris, as well as a list of dictionaries
+    containing the image uri (key: "full") as well as constructed
+    requests to thumbnail (key: "thumbnail") and large (key: "large") versions
+    of the image for use on the folio mapping page.
+    """
+    uris_objs = []
+    uris = []
+    manifest_json = urllib.request.urlopen(manifest_url)
+    manifest_data = json.loads(manifest_json.read().decode("utf-8"))
+    for canvas in manifest_data["sequences"][0]["canvases"]:
+        service = canvas["images"][0]["resource"]["service"]
+        uri = service["@id"]
+        uris.append(uri)
+        path_tail = "default.jpg"
+        uris_objs.append(
+            {
+                "full": uri,
+                "thumbnail": uri + "/full/,160/0/" + path_tail,
+                "large": uri + "/full/,1800/0/" + path_tail,
+            }
+        )
+    return uris, uris_objs
+
+
+def _extract_imagelinks(folios_objs):
+    """
+    Extracts image links, if available, from the folios queryset.
+
+    Parameters
+    ----------
+    folios_objs : django.db.models.query.QuerySet
+        Queryset of Folio objects.
+    """
+    imagelinks_folios = folios_objs.values_list("number", "image_link")
+    imagelinks_ids = _extract_ids([i[1] for i in imagelinks_folios if len(i[1]) > 0])
+    imagelink_folio_map = dict(zip(imagelinks_ids, [i[0] for i in imagelinks_folios]))
+    return imagelink_folio_map
 
 
 def _extract_ids(str_list):

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -72,10 +72,12 @@ class MapFoliosView(APIView):
         if map_status == "UNMAPPED":
             imagelinks = folios_query.values_list("number", "image_link")
             imagelinks_ids = _extract_ids([i[1] for i in imagelinks if len(i[1]) > 0])
-            imagelink_folio = {k: v for k, v in zip(imagelinks_ids, [i[0] for i in imagelinks])}
+            imagelink_folio = {
+                k: v for k, v in zip(imagelinks_ids, [i[0] for i in imagelinks])
+            }
 
         # Iterate through manifest uris.
-        # When a manuscript is already mapped, 
+        # When a manuscript is already mapped,
         # map uris to folios based on the existing image_uri field.
         # Where not mapped, try to map uris to folios based on the
         # image_link field. If a manuscript is not mapped, and
@@ -97,7 +99,7 @@ class MapFoliosView(APIView):
         if mapped_folios == 0 and len(uris_objs) >= len(folios):
             for idx, folio in enumerate(folios):
                 uris_objs[idx]["folio"] = [folio]
-        
+
         return Response(
             {
                 "uris": uris_objs,

--- a/app/public/cantusdata/views/map_folios.py
+++ b/app/public/cantusdata/views/map_folios.py
@@ -96,8 +96,8 @@ class MapFoliosView(APIView):
 
         if mapped_folios == 0 and len(uris_objs) >= len(folios):
             for idx, folio in enumerate(folios):
-                uris_objs[idx]["folio"] = folio
-
+                uris_objs[idx]["folio"] = [folio]
+        
         return Response(
             {
                 "uris": uris_objs,


### PR DESCRIPTION
Improves or fixes many steps to map folios, back-up previous folio mappings, and import mapping back-ups. Fixes #661. Many of these changes adjust the folio mapping back-up process to account for manuscripts with multiple folios per image, introduced in #555.

This PR makes the following changes/resolves the following issues:
1. The csv map folios export is now named with the manuscript ID so that csv backups for different manuscripts can be easily distinguished.
2. Extra lines in csv back-ups have been removed.
3. Csv back-ups now automatically populate the map folios input boxes upon upload. 
4. The map folios Django view logic has been slightly re-factored to better support imports. 
