### PR TITLE
Fix template strings from PR #702

### DIFF
--- a/nginx/public/node/frontend/public/js/app/routers/RouteController.js
+++ b/nginx/public/node/frontend/public/js/app/routers/RouteController.js
@@ -99,8 +99,8 @@ export default Marionette.Object.extend({
         this.listenToOnce(this.manuscriptState, 'load:manuscript', function (model)
         {
             this.showContentView(new ManuscriptDetailPageView({model: model}), {
-                title: `{model.get("provenance")}, {model.get("siglum")}`,
-                navbarTitle: `{model.get("provenance")}, {model.get("siglum")}`
+                title: `${model.get("provenance")}, ${model.get("siglum")}`,
+                navbarTitle: `${model.get("provenance")}, ${model.get("siglum")}`
             });
         });
 


### PR DESCRIPTION
In adding template strings (backtick strings) to the definition of the page title in RouteController.js in #702, I failed to put a `$` ahead of the brackets. This PR fixes that minor issue.