### PR TITLE
Add genre to text field in solr schema

### DIFF
--- a/solr/solr/collection1/conf/schema.xml
+++ b/solr/solr/collection1/conf/schema.xml
@@ -202,6 +202,7 @@
     <copyField source="incipit" dest="text" />
     <copyField source="full_text" dest="text" />
     <copyField source="folio" dest="text" />
+    <copyField source="genre" dest="text" />
     <!-- Above, multiple source fields are copied to the [text] field.
          Another way to map multiple source fields to the same
          destination field is to use the dynamic field syntax.


### PR DESCRIPTION
Multiple chant fields are added to the "text" element in the solr schema so that those fields are included in an "All Text Fields" search. Previously, the genre field was not included, so the genre field was not searched in an "All Text Fields" search. This modifies the solr schema so the genre field is included in that search.

Closes #549 