### PR TITLE
Fix mode search

### DIFF
--- a/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
@@ -96,14 +96,16 @@ export default Marionette.Object.extend({
 
     getSearchMetadata: function ()
     {
+        let fieldName = this.searchParameters.get('field');
+        let numFound = this.collection.metadata.numFound;
         // Modify query returned by solr so it is ready for display.
         // Remove escaping backslashes from the displayed string.
         let query = this.searchParameters.get('query');
-        let displayedQuery = query.replaceAll("\\-", "-");
+        let displayedQuery = (fieldName === "volpiano" || fieldName === "volpiano_literal") ? query.replaceAll("\\-", "-") : query;
         return {
-            fieldName: this.searchParameters.get('field'),
+            fieldName: fieldName,
             query: query,
-            numFound: this.collection.metadata.numFound,
+            numFound: numFound,
             displayedQuery: displayedQuery
         };
     },

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
@@ -156,10 +156,19 @@ export default Marionette.Object.extend({
                 query = query.split(',');
         }
 
+        // The default sort order is defined in the SearchInput model: by
+        // folio ascending. If searching by mode, we sort by Solr's scoring 
+        // and then by the given sort-by parameters
+        // (this gives more appropriate results when multiple 
+        // modes are selected at once).
         var params = {
             sort: this.searchParameters.get('sortBy') + ' ' +
                 (this.searchParameters.get('reverseSort') ? 'desc' : 'asc')
         };
+
+        if (field === 'mode'){
+            params.sort = 'score desc, ' + params.sort;
+        }
 
         var queryBuilder = new SolrQuery({params: params});
 
@@ -179,13 +188,24 @@ export default Marionette.Object.extend({
     },
 
     /**
-     * FIXME(wabain)
-     *
-     * This is an overly complicated workaround to push single-character
-     * mode searches into a field that will return results for them.
-     *
-     * The problem is that currently the mode_t_hidden field doesn't
-     * index single characters
+     * Set field, value pairs in the Solr query. 
+     * 
+     * For non-mode searches, set the value of the field in the 
+     * query to the string entered. Note (as of May 2023): Although a 
+     * connector ("OR") is passed here to the queryBuilder.setField function,
+     * it does not seem like any non-mode searches have multiple values.
+     * Most search types pass strings, while Volpiano-type searches pass 
+     * arrays to this function, but these arrays are of length 1. 
+     * 
+     * For mode searches, we remove the single-letter code prefix from 
+     * the search terms for special modes (eg. "F, Formulaic" --> "Formulaic")
+     * so that the result can be used as a phrase in the query (chant records 
+     * can have "Formulaic" in their mode field but will not have "F, Formulaic").
+     * Mode searches for "basic" modes (eg. "1", "2") are left as-is. We search
+     * the "mode_t_hidden" field, because that field is analyzed (and tokenized)
+     * by Solr to allow results to match partial strings (eg. a chant with mode
+     * "4 Chant in Transposition" will match a search for "4" and "Chant in Transposition").
+     * Multiple selections in a mode search are treated as disjunctions (ORs).
      *
      * @param queryBuilder
      * @param field
@@ -199,39 +219,14 @@ export default Marionette.Object.extend({
             return;
         }
 
-        if (_.isString(query))
-        {
-            queryBuilder.setField(
-                query.length === 1 ? 'mode' : 'mode_t_hidden',
-                query);
-            return;
-        }
-
-        var modeStringValues = [];
-        var modeTextValues = [];
-
-        _.forEach(query, function (value)
-        {
-            if (value.length === 1)
-                modeStringValues.push(value);
-            else
-                modeTextValues.push(value);
-        });
-
-        if (modeStringValues.length === 0)
-            queryBuilder.setField('mode_t_hidden', modeTextValues, 'OR');
-        else if (modeTextValues.length === 0)
-            queryBuilder.setField('mode', modeStringValues, 'OR');
-        else
-        {
-            var hardCodedQuery = '(mode:(' +
-                modeStringValues.join(' OR ') +
-                ') OR mode_t_hidden:(' +
-                modeTextValues.join(' OR ') +
-                '))';
-
-            queryBuilder.setField('_hardcodedSpecialQuery', hardCodedQuery);
-        }
+        let query_modified = [];
+        _.forEach(query, function (value){
+            if (value.length === 1){
+                query_modified.push(value);
+            } else {
+                query_modified.push(`"${value.slice(3)}"`);
+        }});
+        queryBuilder.setField('mode_t_hidden', query_modified, "OR");
     },
 
     /**

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/SearchInputView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/SearchInputView.js
@@ -53,7 +53,7 @@ export default Marionette.ItemView.extend({
         if (searchField === 'volpiano' || searchField === 'volpiano_literal'){
             // Ensure that search input field displays a treble clef as the default
             // search value, and replace it if user deletes it.
-            if (searchInput == "" || searchInput == "1"){
+            if (searchInput === "" || searchInput === "1"){
                 this.ui.searchInput.val("1-");
                 searchInput = "1-";
             }
@@ -97,5 +97,19 @@ export default Marionette.ItemView.extend({
     {
         // Set dynamic classes on the query input
         this.updateQueryInput();
+
+        // If the mode field is selected, 
+        // "select" the previously queried modes
+        if (this.model.get('field') === "mode"){
+            let mode_query = this.model.get('query');
+            for (let i = 0; i < mode_query.length; i++){
+                // We use the first character of each mode search string.
+                // Where the search string is a number, the first character is that
+                // number. 
+                let selected_mode = mode_query[i][0];
+                let mode_input = this.$el.find(`#mode-option-${selected_mode}`);
+                mode_input.attr("selected", true);
+            }
+        }
     }
 });

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/search-input.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/search-input.template.html
@@ -4,19 +4,19 @@
         <% // FIXME(wabain): would a typeahead be better? %>
         <% if (field === 'mode') { %>
         <select multiple class="form-control search-input">
-            <option value="1">Mode 1</option>
-            <option value="2">Mode 2</option>
-            <option value="3">Mode 3</option>
-            <option value="4">Mode 4</option>
-            <option value="5">Mode 5</option>
-            <option value="6">Mode 6</option>
-            <option value="7">Mode 7</option>
-            <option value="8">Mode 8</option>
-            <option>No Music</option>
-            <option>F, Formulaic</option>
-            <option>U, Uncertain</option>
-            <option>R, Responsory (special)</option>
-            <option>T, Chant in Transposition</option>
+            <option id="mode-option-1" value="1">Mode 1</option>
+            <option id="mode-option-2" value="2">Mode 2</option>
+            <option id="mode-option-3" value="3">Mode 3</option>
+            <option id="mode-option-4" value="4">Mode 4</option>
+            <option id="mode-option-5" value="5">Mode 5</option>
+            <option id="mode-option-6" value="6">Mode 6</option>
+            <option id="mode-option-7" value="7">Mode 7</option>
+            <option id="mode-option-8" value="8">Mode 8</option>
+            <option id="mode-option-N">No Music</option>
+            <option id="mode-option-F">F, Formulaic</option>
+            <option id="mode-option-U">U, Uncertain</option>
+            <option id="mode-option-R">R, Responsory (special)</option>
+            <option id="mode-option-T">T, Chant in Transposition</option>
         </select>
             <% } else if (field === 'volpiano' || field === 'volpiano_literal') { %>
                 <input type="text" class="form-control search-input field-<%= field %>"


### PR DESCRIPTION
Closes #710. In the course of solving this, #719 was discovered and involves mode search but is out of scope for this PR. 

The PR has two primary elements:
1. The handling of `mode` searches is simplified and improved. Previously, `mode` searches were analyzed so that multi-character queries matched more than the expected number of results (see #710 for more details; for example, selecting `T, Chant in Transposition` from among the search options would match chants with mode `Uncertain` because the query analyzer would yield a `t` token that would match the `t` token generated by the "t" in `Uncertain`). Multi-character modes are now searched as truncated phrases (in quotes `"` with the initial single-character code removed).
2. When returning to a search window after navigating away, a previous search query (and previous results) are shown. In mode search, the options were not previously highlighted in the selector window when returning to the mode search. Now, those are highlighted upon return so the user can see what the previous search was. 
Eg. Previously, if someone selected `Mode 1` and `Mode 2`, navigated away, and then navigated back, the search results would re-appear, but the search box would look like:
![image](https://github.com/DDMAL/cantus/assets/11023634/932a4a1f-c5a6-45ce-8e71-a32878be20fb)

Now, upon returning, it will look like:
![image](https://github.com/DDMAL/cantus/assets/11023634/f3691108-4e05-453c-8f20-de1f3784aae3)

While these were being corrected, a non-breaking error when the `mode` field is searched that was introduced in #688 was identified. This PR fixes that issue. 