### PR TITLE
Update docker-compose image names to new convention

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -15,5 +15,6 @@ jobs:
       RABBIT_PASSWORD: supersecurepassword99
     steps:
       - uses: actions/checkout@v3
+      - run: docker compose build
       - run: docker compose up -d
       - run: docker compose exec -T app python runtests.py cantusdata.test.core

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -15,5 +15,5 @@ jobs:
       RABBIT_PASSWORD: supersecurepassword99
     steps:
       - uses: actions/checkout@v3
-      - run: docker-compose up -d
-      - run: docker-compose exec -T app python runtests.py cantusdata.test.core
+      - run: docker compose up -d
+      - run: docker compose exec -T app python runtests.py cantusdata.test.core

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,7 +64,7 @@ services:
     restart: always
 
   celery:
-    image: cantus_app
+    image: cantus-app
     container_name: cantus-celery-1
     volumes:
       - ./app/public:/code/public


### PR DESCRIPTION
Convention with the latest version of docker compose is to use a hyphen as the separator in image names. This commit changes the docker-compose yaml to account for this change.

This PR also updates the repo's run-tests GitHub action to use Docker Compose v2. 