### PR TITLE
Change folio navigation search suggestions

### DIFF
--- a/app/public/cantusdata/models/folio.py
+++ b/app/public/cantusdata/models/folio.py
@@ -31,6 +31,7 @@ class Folio(models.Model):
             "item_id": self.id,
             "image_uri": self.image_uri,
             "manuscript_id": self.manuscript.id,
+            "number_wo_lz": self.number.lstrip("0"),
         }
 
     def fetch_solr_records(self, solrconn):

--- a/app/public/cantusdata/models/folio.py
+++ b/app/public/cantusdata/models/folio.py
@@ -31,7 +31,7 @@ class Folio(models.Model):
             "item_id": self.id,
             "image_uri": self.image_uri,
             "manuscript_id": self.manuscript.id,
-            "number_wo_lz": self.number.lstrip("0"),
+            "number_wo_lead_zero": self.number.lstrip("0"),
         }
 
     def fetch_solr_records(self, solrconn):

--- a/app/public/cantusdata/views/folio_set.py
+++ b/app/public/cantusdata/views/folio_set.py
@@ -39,16 +39,12 @@ class ManuscriptFolioSetView(APIView):
                 score=False,
             )
             if results.numFound > 0:
-                # Initialize combined results dict with the first result
-                combined_results = results.results[0]
-                # For manuscripts with double-folio images, add the possible
-                # second folio to the combined results dict.
-                if results.numFound == 2:
-                    for field in FOLIO_FIELDS:
-                        combined_results[field] = [
-                            combined_results[field],
-                            results.results[1][field],
-                        ]
+                result_contents = results.results
+                combined_results = {}
+                for field in FOLIO_FIELDS:
+                    combined_results[field] = [
+                        result_contents[i][field] for i in range(results.numFound)
+                    ]
                 return Response(combined_results)
             if results.numFound == 0:
                 return Response({"number": None})

--- a/app/public/cantusdata/views/folio_set.py
+++ b/app/public/cantusdata/views/folio_set.py
@@ -52,9 +52,8 @@ class ManuscriptFolioSetView(APIView):
             # the manuscript that have the form:
             # [some number of leading zeros][the user-entered string][wildcard of characters].
             # Here we assume at most 3 leading zeros.
-            composed_request = f"""type:"cantusdata_folio" AND manuscript_id:{manuscript_id}
-                                 AND number:(000{query_str}* OR 00{query_str}* OR 0{query_str}*
-                                 OR {query_str}*)"""
+            composed_request = f"""type:"cantusdata_folio" AND manuscript_id:{manuscript_id} 
+                                AND number_wo_lz:{query_str}*"""
             results = solrconn.query(
                 composed_request,
                 sort="number asc",

--- a/app/public/cantusdata/views/folio_set.py
+++ b/app/public/cantusdata/views/folio_set.py
@@ -25,35 +25,43 @@ class ManuscriptFolioSetView(APIView):
 
         manuscript_id = kwargs["pk"]
 
+        # If the request contains an image_uri parameter, return the folio(s)
+        # associated with that image.
         if "image_uri" in kwargs:
             image_uri = kwargs["image_uri"]
             composed_request = f'''type:"cantusdata_folio" AND
                  manuscript_id:{manuscript_id} AND image_uri:"{image_uri}"'''
-            result = solrconn.query(
+            results = solrconn.query(
                 composed_request,
                 sort="number asc",
                 rows=2,
                 fields=FOLIO_FIELDS,
                 score=False,
             )
-
-            if result.results:
-                results_dict = {
-                    key: [res[key] for res in result.results]
-                    for key in result.results[0].keys()
-                }
-                return Response(results_dict)
-            if result.numFound == 0:
+            if results.numFound > 0:
+                # Initialize combined results dict with the first result
+                combined_results = results.results[0]
+                # For manuscripts with double-folio images, add the possible
+                # second folio to the combined results dict.
+                if results.numFound == 2:
+                    for field in FOLIO_FIELDS:
+                        combined_results[field] = [
+                            combined_results[field],
+                            results.results[1][field],
+                        ]
+                return Response(combined_results)
+            if results.numFound == 0:
                 return Response({"number": None})
             raise Http404("Folio set query failed.")
+        # If a query parameter is passed, return suggested folios
+        # for navigation.
         if "q" in request.GET:
             query_str = request.GET["q"]
             # Query for suggested folio numbers should return folios associated with
             # the manuscript that have the form:
             # [some number of leading zeros][the user-entered string][wildcard of characters].
-            # Here we assume at most 3 leading zeros.
-            composed_request = f"""type:"cantusdata_folio" AND manuscript_id:{manuscript_id} 
-                                AND number_wo_lz:{query_str}*"""
+            composed_request = f"""type:"cantusdata_folio" AND manuscript_id:{manuscript_id}
+                                AND number_wo_lead_zero:{query_str}*"""
             results = solrconn.query(
                 composed_request,
                 sort="number asc",
@@ -62,6 +70,7 @@ class ManuscriptFolioSetView(APIView):
                 score=False,
             )
             return Response(results)
+        # Otherwise, simply return the given manuscript's folios.
         composed_request = f'type:"cantusdata_folio" AND manuscript_id:{manuscript_id}'
         results = solrconn.query(
             composed_request,

--- a/solr/solr/cantus_ultimus_1/conf/schema.xml
+++ b/solr/solr/cantus_ultimus_1/conf/schema.xml
@@ -27,6 +27,9 @@
     <field name="description" type="text_general" indexed="true" stored="true" />
     <field name="public" type="boolean" default="true" indexed="true" stored="true" />
     <field name="number" type="string" indexed="true" stored="true" />
+    <!-- This field removes leading zeros from the folio number in order
+    to offer better folio navigation search suggestions -->
+    <field name="number_wo_lz" type="string" indexed="true" stored="false" />
     <field name="manuscript" type="text_general" indexed="true" stored="true" />
     <field name="manuscript_id" type="int" indexed="true" stored="true" />
     <field name="manuscript_name_hidden" type="string" indexed="false" stored="true" />

--- a/solr/solr/cantus_ultimus_1/conf/schema.xml
+++ b/solr/solr/cantus_ultimus_1/conf/schema.xml
@@ -29,7 +29,7 @@
     <field name="number" type="string" indexed="true" stored="true" />
     <!-- This field removes leading zeros from the folio number in order
     to offer better folio navigation search suggestions -->
-    <field name="number_wo_lz" type="string" indexed="true" stored="false" />
+    <field name="number_wo_lead_zero" type="string" indexed="true" stored="false" />
     <field name="manuscript" type="text_general" indexed="true" stored="true" />
     <field name="manuscript_id" type="int" indexed="true" stored="true" />
     <field name="manuscript_name_hidden" type="string" indexed="false" stored="true" />


### PR DESCRIPTION
The solr query used to find suggestions for the folio navigation search is modified to provide more useful results. We assume that the string typed by the user is the beginning of the folio number they wish to search (after some number of leading zeros) with a wildcard following.

For example, previously if a user typed in 4, they would receive suggestions like 0014r and 0034v when those are less likely that folios like 0041r and 0401r.

This PR introduces an index field that is the folio number stripped of leading zeros. This is then the field searched in order to provide suggestions.

Closes https://github.com/DDMAL/cantus/issues/564