### PR TITLE
Specify version of rabbitmq to use for docker container

### DIFF
--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -1,1 +1,1 @@
-FROM rabbitmq
+FROM rabbitmq:3.11


### PR DESCRIPTION
Closes #692 by specifying a  version of RabbitMQ to use. The version selected is the latest minor version (as of 29 May 2023) released. EOL for RabbitMQ 3.11 is not currently specified.