### PR TITLE
Remove extra scroll bars on manuscript detail view

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -4,12 +4,13 @@ RUN npm install -g gulp
 
 WORKDIR /code/frontend
 RUN npm install
-COPY ./public/node/ /code/
+RUN mkdir -p ../static/fonts
 RUN wget http://www.fawe.de/volpiano/volpiano51_web.zip
 RUN unzip volpiano51_web.zip
 RUN rm volpiano51_web.zip
 RUN mv volpiano51_web/volpiano.woff ../static/fonts/volpiano.woff
-RUN gulp build --release
+COPY ./public/node/ /code/
+RUN gulp build
 
 FROM python:3.6.9 AS django-static
 COPY ./public/python /code

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -10,7 +10,7 @@ RUN unzip volpiano51_web.zip
 RUN rm volpiano51_web.zip
 RUN mv volpiano51_web/volpiano.woff ../static/fonts/volpiano.woff
 COPY ./public/node/ /code/
-RUN gulp build
+RUN gulp build --release
 
 FROM python:3.6.9 AS django-static
 COPY ./public/python /code

--- a/nginx/public/node/frontend/public/css/styles.scss
+++ b/nginx/public/node/frontend/public/css/styles.scss
@@ -264,7 +264,6 @@ pre.preformatted-text {
 }
 
 .result-table-wrapper {
-    overflow: auto;
     min-height: 200px;
 }
 
@@ -281,15 +280,15 @@ pre.preformatted-text {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    overflow: scroll;
-
-    // Workaround for Safari, where elements would shrink if the chant list was too big
-    > * {
-        flex-shrink: 0;
-    }
 
     > .propagate-height, > .result-table-wrapper, > .modal-body {
         flex-shrink: 1;
+        overflow:auto;
+    }
+
+    > .row {
+        margin-right: 0px;
+        margin-left:0px;
     }
 
     // Workaround for Bootstrap tabs
@@ -335,11 +334,6 @@ body.propagate-height {
 .modal-content {
     height: 100%;
 }
-// Fix a bug in the modal content where the search drop-down would be hidden
-// ^This doesn't seem to be happening, and it was stopping the list from being scrollable - eli
-// .modal-content > .modal-body > .propagate-height {
-//     overflow: visible;
-// }
 
 #manuscript-data-container {
     // Relative-position the container so that percentage-based dimensions are calculated relative to it
@@ -371,11 +365,6 @@ body.propagate-height {
                 margin-left: 1px;
             }
         }
-    }
-
-    //Allow chants to be scrolled in the manuscript-info pane
-    .tab-content {
-        overflow: auto;
     }
 }
 


### PR DESCRIPTION
This PR removes extra scroll bars that had appeared on the manuscript detail view (and in the mean-time removes some extraneous styling from our scss.

This PR also includes a slight re-ordering of the `nginx` container build that slightly reduces build time during development of the front-end. We install the volpiano font before copying the rest of the front-end code into the container so we don't have to re-download the font everytime we change the front-end. 

Closes #677.

Thanks for the debug help @zhannaklimanova 