### PR TITLE
Fix search suggesters

### DIFF
--- a/app/django-config.sh
+++ b/app/django-config.sh
@@ -7,5 +7,5 @@ python manage.py clear_session_data
 if [[ $APP_PORT = 80 ]]; then
     gunicorn -b 0:8001 cantusdata.wsgi --timeout 600 --workers 4
 else
-    python manage.py runserver 0:8001
+    python manage.py runserver_plus 0:8001
 fi

--- a/app/public/cantusdata/views/suggestion.py
+++ b/app/public/cantusdata/views/suggestion.py
@@ -49,5 +49,4 @@ class SuggestionView(APIView):
             # The names of the facets (ie. the suggestions) are in the even indices of the list
             facet_counts = facet_counts[::2]
             suggestion_objs = [{"term": term} for term in facet_counts]
-            response = Response(suggestion_objs)
-            return response
+            return Response(suggestion_objs)

--- a/app/public/cantusdata/views/suggestion.py
+++ b/app/public/cantusdata/views/suggestion.py
@@ -3,48 +3,50 @@ from rest_framework.response import Response
 from django.conf import settings
 
 import solr
+import requests
 
 
 class SuggestionView(APIView):
+    """
+    A view providing search suggestions. Currently,
+     suggestions are only provided for the following fields:
+     - office
+     - genre
+     - feast
+
+     For these fields, the suggestions are provided by facet counts.
+    """
+
     def get(self, request, *args, **kwargs):
-        if not ("q" in request.GET and "dictionary" in request.GET):
+        if not ("q" in request.GET and "field" in request.GET):
             return Response()
 
-        q = "{0}".format(request.GET["q"])
-        dictionary = "{0}".format(request.GET["dictionary"])  # The suggester to use
-        manuscript = "{0}".format(
-            request.GET["manuscript"]
-        )  # Can be '*' when searching through all manuscripts
+        query = request.GET["q"]
+        field = request.GET["field"]
+        manuscript_id = request.GET[
+            "manuscript_id"
+        ]  # '*' when searching through all manuscripts
 
-        connection = solr.Solr(settings.SOLR_SERVER)
-        search_handler = solr.SearchHandler(connection, "/suggest")
+        if field not in ["office", "genre", "feast"]:
+            return Response()
 
-        # TODO fix solr so that the suggesters work with a context field (cfq)]
-        # search_results = search_handler(q=q, suggest_dictionary=dictionary, suggest_cfq=manuscript)
-        search_results = search_handler(q=q, suggest_dictionary=dictionary)
-
-        results = search_results.suggest[dictionary][q]
-
-        # Remove duplicates from the suggestions and limits the return number to 10
-        results["suggestions"] = self._get_filtered_results(results["suggestions"])
-
-        response = Response(results)
-        return response
-
-    def _get_filtered_results(self, suggestions):
-        results = []
-        for suggestion in suggestions:
-            unique = True
-
-            for result in results:
-                if suggestion["term"] == result["term"]:
-                    unique = False
-                    break
-
-            if unique:
-                results.append(suggestion)
-
-            if len(results) == 10:
-                break
-
-        return results
+        solr_server = settings.SOLR_SERVER
+        results = requests.get(
+            f"{solr_server}/select",
+            params={
+                "q": "*:*",
+                "rows": 0,
+                "facet": "true",
+                "fq": f"manuscript_id:{manuscript_id}",
+                "facet.field": field,
+                "facet.limit": 8,
+                "facet.contains": query,
+                "facet.contains.ignoreCase": "true",
+            },
+        )
+        if results.status_code == 200:
+            facet_counts = results.json()["facet_counts"]["facet_fields"][field]
+            # The names of the facets (ie. the suggestions) are in the even indices of the list
+            facet_counts = facet_counts[::2]
+            response = Response(facet_counts)
+            return response

--- a/app/public/cantusdata/views/suggestion.py
+++ b/app/public/cantusdata/views/suggestion.py
@@ -48,5 +48,6 @@ class SuggestionView(APIView):
             facet_counts = results.json()["facet_counts"]["facet_fields"][field]
             # The names of the facets (ie. the suggestions) are in the even indices of the list
             facet_counts = facet_counts[::2]
-            response = Response(facet_counts)
+            suggestion_objs = [{"term": term} for term in facet_counts]
+            response = Response(suggestion_objs)
             return response

--- a/app/public/requirements.txt
+++ b/app/public/requirements.txt
@@ -9,3 +9,4 @@ solrpy==0.9.9
 coverage==4.0.3
 celery==5.1.2
 django-celery-results==2.4.0
+Werkzeug==2.0.3

--- a/nginx/public/node/frontend/public/js/app/collections/SuggestionCollection.js
+++ b/nginx/public/node/frontend/public/js/app/collections/SuggestionCollection.js
@@ -14,6 +14,6 @@ export default Backbone.Collection.extend({
 
     parse: function(data)
     {
-        return data.suggestions;
+        return data;
     }
 });

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/suggestions/SuggestionCollectionView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/suggestions/SuggestionCollectionView.js
@@ -48,7 +48,7 @@ export default Marionette.CompositeView.extend({
         // Get the active suggestion
         var el = this.$('.active');
         // Add boolean operator 'AND' between all words, in order to match exactly the suggestion
-        var text = el.text().replace(/(?!^)\s+(?!$)/g, ' AND ');
+        var text = `"${el.text()}"`
         this.trigger('click:suggestion', null, text);
         this.hide();
     },

--- a/nginx/public/node/frontend/public/js/app/utils/SolrQuery.js
+++ b/nginx/public/node/frontend/public/js/app/utils/SolrQuery.js
@@ -168,15 +168,14 @@ var SolrQuery = Marionette.Object.extend({
         var self = this;
         var suggestString = null;
 
+        // We currently only provide suggestions for feast, genre, and office
         ['feast', 'genre', 'office'].forEach(function (field)
         {
-            var term = self.fields[field] || self.fields[field + '_t_hidden'];
+            var term = self.fields[field + '_t_hidden'];
             if (term)
             {
-                var manuscript = self.fields.manuscript || '*';
-                suggestString = 'q=' + self.getSolrTerm(term, false) +
-                    '&dictionary=' + field + 'Suggester' +
-                    '&manuscript=' + manuscript;
+                var manuscript_id = self.fields.manuscript_id || '*';
+                suggestString = `q=${self.getSolrTerm(term, false)}&field=${field}&manuscript_id=${manuscript_id}`;
             }
         });
 

--- a/solr/solr/cantus_ultimus_1/conf/schema.xml
+++ b/solr/solr/cantus_ultimus_1/conf/schema.xml
@@ -46,8 +46,8 @@
     <field name="feast_date" type="text_general" indexed="true" stored="true" multiValued="false" />
     <field name="feast_code" type="text_general" indexed="true" stored="true" multiValued="false" />
     <field name="feast_explanation" type="text_general" indexed="true" stored="true" multiValued="false" />
-    <!-- This field is necessary for the suggesters to work but is empty -->
-    <field name="weight_field" type="float" indexed="false" stored="true" />
+    <!-- The "weight_field" field is necessary for the suggesters to work but is empty -->
+    <!-- <field name="weight_field" type="float" indexed="false" stored="true" /> -->
     <field name="office" type="string" indexed="true" stored="true" multiValued="false" />
     <field name="genre" type="string" indexed="true" stored="true" multiValued="false" />
     <field name="position" type="string" indexed="true" stored="true" multiValued="false" />
@@ -61,7 +61,6 @@
     <field name="volpiano_literal" type="volpiano_literal" indexed="true" stored="false" multiValued="false" />
     <field name="concordances" type="string" indexed="true" stored="true" multiValued="true" />
     <!-- Fields related to OMR Data -->
-    <!-- <field name="suggest" type="suggestions" indexed="true" multiValued="true" /> -->
     <field name="pagen" type="int" indexed="true" stored="true" required="false" />
     <field name="pnames" type="string" indexed="true" stored="true" required="false" />
     <field name="neumes" type="string" indexed="true" stored="true" required="false" />
@@ -190,6 +189,8 @@
         </analyzer>
     </fieldType>
 
+    <!-- This field type is not currently used, but is used by the commented 
+    suggester configuration. See comment in solrconfig.xml for more details. -->
     <!-- <fieldtype name="text_suggest" class="solr.TextField">
         <analyzer type="index">
             <tokenizer class="solr.StandardTokenizerFactory" />

--- a/solr/solr/cantus_ultimus_1/conf/schema.xml
+++ b/solr/solr/cantus_ultimus_1/conf/schema.xml
@@ -189,6 +189,17 @@
             <filter class="solr.LowerCaseFilterFactory" />
         </analyzer>
     </fieldType>
+
+    <!-- <fieldtype name="text_suggest" class="solr.TextField">
+        <analyzer type="index">
+            <tokenizer class="solr.StandardTokenizerFactory" />
+            <filter class="solr.LowerCaseFilterFactory" />
+        </analyzer>
+        <analyzer type="index">
+            <tokenizer class="solr.StandardTokenizerFactory" />
+            <filter class="solr.LowerCaseFilterFactory" />
+        </analyzer>
+    </fieldtype> -->
   
    <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
 </schema>

--- a/solr/solr/cantus_ultimus_1/conf/solrconfig.xml
+++ b/solr/solr/cantus_ultimus_1/conf/solrconfig.xml
@@ -90,39 +90,18 @@
         </lst>
     </initParams>
 
-    <!-- Define the suggestion components for office, genre, and feast -->
+    <!-- Define the suggestion components for office.
+    We do not use the built-in suggester to provide suggestions
+    for these fields (the facet query defined in the "suggestion.py" view
+    in the backend provides better results). However, this is a working 
+    suggester configuration with the solr update, so I'm keeping this commented
+    to provide direction if search suggestions are desired in the future. -->
     <!-- <searchComponent name="suggest" class="solr.SuggestComponent">
         <lst name="suggester">
             <str name="name">OfficeSuggester</str>
             <str name="lookupImpl">BlendedInfixLookupFactory</str>
             <str name="dictionaryImpl">DocumentDictionaryFactory</str>
             <str name="field">office</str>
-            <str name="suggestAnalyzerFieldType">text_suggest</str>
-            <str name="buildOnStartup">false</str>
-            <str name="buildOnCommit">true</str>
-            <str name="weightField">weight</str>
-            <str name="highlight">false</str>
-            <str name="contextField">manuscript_id</str>
-            <str name="numFactor">2</str>
-        </lst>
-        <lst name="suggester">
-            <str name="name">FeastSuggester</str>
-            <str name="lookupImpl">BlendedInfixLookupFactory</str>
-            <str name="dictionaryImpl">DocumentDictionaryFactory</str>
-            <str name="field">feast</str>
-            <str name="suggestAnalyzerFieldType">text_suggest</str>
-            <str name="buildOnStartup">false</str>
-            <str name="buildOnCommit">true</str>
-            <str name="weightField">weight</str>
-            <str name="highlight">false</str>
-            <str name="contextField">manuscript_id</str>
-            <str name="numFactor">2</str>
-        </lst>
-        <lst name="suggester">
-            <str name="name">GenreSuggester</str>
-            <str name="lookupImpl">BlendedInfixLookupFactory</str>
-            <str name="dictionaryImpl">DocumentDictionaryFactory</str>
-            <str name="field">genre</str>
             <str name="suggestAnalyzerFieldType">text_suggest</str>
             <str name="buildOnStartup">false</str>
             <str name="buildOnCommit">true</str>

--- a/solr/solr/cantus_ultimus_1/conf/solrconfig.xml
+++ b/solr/solr/cantus_ultimus_1/conf/solrconfig.xml
@@ -89,4 +89,59 @@
             <str name="df">text</str>
         </lst>
     </initParams>
+
+    <!-- Define the suggestion components for office, genre, and feast -->
+    <!-- <searchComponent name="suggest" class="solr.SuggestComponent">
+        <lst name="suggester">
+            <str name="name">OfficeSuggester</str>
+            <str name="lookupImpl">BlendedInfixLookupFactory</str>
+            <str name="dictionaryImpl">DocumentDictionaryFactory</str>
+            <str name="field">office</str>
+            <str name="suggestAnalyzerFieldType">text_suggest</str>
+            <str name="buildOnStartup">false</str>
+            <str name="buildOnCommit">true</str>
+            <str name="weightField">weight</str>
+            <str name="highlight">false</str>
+            <str name="contextField">manuscript_id</str>
+            <str name="numFactor">2</str>
+        </lst>
+        <lst name="suggester">
+            <str name="name">FeastSuggester</str>
+            <str name="lookupImpl">BlendedInfixLookupFactory</str>
+            <str name="dictionaryImpl">DocumentDictionaryFactory</str>
+            <str name="field">feast</str>
+            <str name="suggestAnalyzerFieldType">text_suggest</str>
+            <str name="buildOnStartup">false</str>
+            <str name="buildOnCommit">true</str>
+            <str name="weightField">weight</str>
+            <str name="highlight">false</str>
+            <str name="contextField">manuscript_id</str>
+            <str name="numFactor">2</str>
+        </lst>
+        <lst name="suggester">
+            <str name="name">GenreSuggester</str>
+            <str name="lookupImpl">BlendedInfixLookupFactory</str>
+            <str name="dictionaryImpl">DocumentDictionaryFactory</str>
+            <str name="field">genre</str>
+            <str name="suggestAnalyzerFieldType">text_suggest</str>
+            <str name="buildOnStartup">false</str>
+            <str name="buildOnCommit">true</str>
+            <str name="weightField">weight</str>
+            <str name="highlight">false</str>
+            <str name="contextField">manuscript_id</str>
+            <str name="numFactor">2</str>
+        </lst>
+    </searchComponent>
+
+    <requestHandler name="/suggest" class="solr.SearchHandler" startup="lazy">
+        <lst name="defaults">
+            <str name="suggest">true</str>
+            <str name="suggest.count">10</str>
+        </lst>
+    <arr name="components">
+      <str>suggest</str>
+    </arr>
+    </requestHandler> -->
+
+
 </config>


### PR DESCRIPTION
This PR fixes search suggestions for the `feast`, `office`, and `genre` search. These suggestions are provided both for the global site search (accessed from the "Search" button in the Cantus Ultimus header) and the manuscript-specific search (access from the manuscript detail page). Search suggestions are provided by a facet search.

This PR also provides a (commented out) working configuration for a search suggester that ships with solr. While we don't use a solr suggester for this use case, that configuration is left in the solrconfig.xml file and schema.xml file for potential use in other situations; it was finicky, so I didn't want to delete it entirely. 

Fixes #730. Fixes #716.

Because it is a minor change, this PR also includes https://github.com/DDMAL/cantus/pull/733/commits/5deb712343f737aab5c5944bea1d68501c32545d, which adds the Werkzeug package and makes `runserver_plus` the default command for development. #734 has been opened to introduce better dependency management for Cantus Ultimus.