### PR TITLE
Include manuscript spelling text in full text search

### DIFF
--- a/solr/solr/cantus_ultimus_1/conf/schema.xml
+++ b/solr/solr/cantus_ultimus_1/conf/schema.xml
@@ -112,6 +112,7 @@
     <copyField source="marginalia" dest="text" />
     <copyField source="incipit" dest="text" />
     <copyField source="full_text" dest="text" />
+    <copyField source="full_text_ms" dest="text" />
     <copyField source="folio" dest="text" />
     <copyField source="genre" dest="text" />
 


### PR DESCRIPTION
Closes #751. Adds manuscript spelling field to the full text search in the solr schema.