### PR TITLE
Navigate to pageAlias set in url

### DIFF
--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/DivaView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/DivaView.js
@@ -252,18 +252,19 @@ export default Marionette.ItemView.extend({
             error: _.bind(function(response)
             {
                 // We didn't find a match; fall back to treating this as a non-aliased page number
-                if (alias.match(/^\d+$/))
+                if (alias.match(/^Image (\d+)$/)){
+                    var pageIndex = parseInt(alias.match(/^Image (\d+)$/)[1], 10) - 1;
+                } else if (alias.match(/^\d+$/))
                 {
                     var pageIndex = parseInt(alias, 10) - 1;
-
-                    if (pageIndex >= 0 && pageIndex < this.divaFilenames.length)
+                }
+                if (pageIndex >= 0 && pageIndex < this.divaFilenames.length)
                     {
                         return deferred.resolve(this.divaFilenames[pageIndex]);
+                    } else {
+                        // If nothing worked, then just return null
+                        return deferred.reject(response);
                     }
-                }
-
-                // If nothing worked, then just return null
-                return deferred.reject(response);
             }, this)
         });
 
@@ -287,7 +288,7 @@ export default Marionette.ItemView.extend({
         this._customizeToolbar();
 
         // Go to the predetermined initial folio if one is set
-        var initialFolio = manuscriptChannel.request('folio');
+        var initialFolio = manuscriptChannel.request('folio') ? manuscriptChannel.request('folio') : manuscriptChannel.request('pageAlias');
         if (initialFolio !== null)
         {
             this.getPageWhichMatchesAlias(initialFolio).done(_.bind(function (initialImageURI)

--- a/nginx/public/node/frontend/public/js/app/models/ManuscriptStateModel.js
+++ b/nginx/public/node/frontend/public/js/app/models/ManuscriptStateModel.js
@@ -65,7 +65,7 @@ export default Backbone.Model.extend({
     {
         this.manuscriptModel = null;
 
-        if (!this.hasChanged('folio'))
+        if (!this.hasChanged('folio') && !this.hasChanged('pageAlias'))
         {
             this.set('folio', null);
             this.set('pageAlias', null);

--- a/nginx/public/node/frontend/public/js/app/routers/RouteController.js
+++ b/nginx/public/node/frontend/public/js/app/routers/RouteController.js
@@ -72,7 +72,7 @@ export default Marionette.Object.extend({
     manuscriptSingle: function(id, query)
     {
         var params = Qs.parse(query);
-        var state = _.extend({manuscript: id}, _.pick(params, ['folio', 'chant', 'search']));
+        var state = _.extend({manuscript: id}, _.pick(params, ['folio', 'chant', 'search','pageAlias']));
 
         // Update the manuscript state model if necessary; don't reload the whole
         // view if the manuscript has not changed


### PR DESCRIPTION
Closes #703. 

With this PR, we now set `pageAlias` on the `ManuscriptState` model if a pageAlias is provided. 

Previously, if no valid folio was provided upon initialization of the Diva view, there was logic that assumed that the provided parameter was the page number of the image in the manifest. This logic has been revised so that if the folio is not provided, then the pageAlias is used and this parameter is properly parsed for use in setting the image.