### PR TITLE
Fix BNF sigla in manifests.csv

### DIFF
--- a/app/public/data_dumps/manifests.csv
+++ b/app/public/data_dumps/manifests.csv
@@ -29,20 +29,20 @@ D-W 28 Helmst.,https://iiif.hab.de/object/mss_28-helmst/manifest
 D-W 29 Helmst.,https://iiif.hab.de/object/mss_29-helmst/manifest
 D-WI1 2,http://tudigit.ulb.tu-darmstadt.de/show/iiif/Hild_R_Riesencodex/manifest.json
 F-AS 893,https://bvmm.irht.cnrs.fr/iiif/24878/manifest
-F-Pnm lat. 1085,https://gallica.bnf.fr/iiif/ark:/12148/btv1b100389982/manifest.json?iiif-content=https://gallica.bnf.fr/iiif/ark:/12148/btv1b100389982/manifest.json 
-F-Pnm lat. 1090,https://gallica.bnf.fr/iiif/ark:/12148/btv1b60007359/manifest.json
-F-Pnm lat. 1112,https://gallica.bnf.fr/iiif/ark:/12148/btv1b6000450z/manifest.json
-F-Pnm lat. 12044,https://gallica.bnf.fr/iiif/ark:/12148/btv1b6000531z/manifest.json
-F-Pnm lat. 12054,https://gallica.bnf.fr/iiif/ark:/12148/btv1b8422976g/manifest.json
-F-Pnm lat. 1240,https://gallica.bnf.fr/iiif/ark:/12148/btv1b6000528g/manifest.json?iiif-content=https://gallica.bnf.fr/iiif/ark:/12148/btv1b6000528g/manifest.json 
-F-Pnm lat. 12601,https://gallica.bnf.fr/iiif/ark:/12148/btv1b84229789/manifest.json?iiif-content=https://gallica.bnf.fr/iiif/ark:/12148/btv1b84229789/manifest.json
-F-Pnm lat. 15181,https://gallica.bnf.fr/iiif/ark:/12148/btv1b8447768b/manifest.json 
-F-Pnm lat. 15182,https://gallica.bnf.fr/iiif/ark:/12148/btv1b8447769r/manifest.json?iiif-content=https://gallica.bnf.fr/iiif/ark:/12148/btv1b8447769r/manifest.json 
-F-Pnm lat. 776,https://gallica.bnf.fr/iiif/ark:/12148/btv1b84546727/manifest.json
-F-Pnm lat. 943,https://gallica.bnf.fr/iiif/ark:/12148/btv1b6001165p/manifest.json
-F-Pnm n.a.lat. 1412,https://gallica.bnf.fr/iiif/ark:/12148/btv1b100357501/manifest.json
-F-Pnm n.a.lat. 1535,https://gallica.bnf.fr/iiif/ark:/12148/btv1b100337650/manifest.json
-F-Pnm NAL 1411,https://gallica.bnf.fr/iiif/ark:/12148/btv1b10033588d/manifest.json
+F-Pn Lat. 1085,https://gallica.bnf.fr/iiif/ark:/12148/btv1b100389982/manifest.json?iiif-content=https://gallica.bnf.fr/iiif/ark:/12148/btv1b100389982/manifest.json 
+F-Pn Lat. 1090,https://gallica.bnf.fr/iiif/ark:/12148/btv1b60007359/manifest.json
+F-Pn Lat. 1112,https://gallica.bnf.fr/iiif/ark:/12148/btv1b6000450z/manifest.json
+F-Pn Lat. 12044,https://gallica.bnf.fr/iiif/ark:/12148/btv1b6000531z/manifest.json
+F-Pn Lat. 12054,https://gallica.bnf.fr/iiif/ark:/12148/btv1b8422976g/manifest.json
+F-Pn Lat. 1240,https://gallica.bnf.fr/iiif/ark:/12148/btv1b6000528g/manifest.json?iiif-content=https://gallica.bnf.fr/iiif/ark:/12148/btv1b6000528g/manifest.json 
+F-Pn Lat. 12601,https://gallica.bnf.fr/iiif/ark:/12148/btv1b84229789/manifest.json?iiif-content=https://gallica.bnf.fr/iiif/ark:/12148/btv1b84229789/manifest.json
+F-Pn Lat. 15181,https://gallica.bnf.fr/iiif/ark:/12148/btv1b8447768b/manifest.json 
+F-Pn Lat. 15182,https://gallica.bnf.fr/iiif/ark:/12148/btv1b8447769r/manifest.json?iiif-content=https://gallica.bnf.fr/iiif/ark:/12148/btv1b8447769r/manifest.json 
+F-Pn Lat. 776,https://gallica.bnf.fr/iiif/ark:/12148/btv1b84546727/manifest.json
+F-Pn Lat. 943,https://gallica.bnf.fr/iiif/ark:/12148/btv1b6001165p/manifest.json
+F-Pn NAL 1412,https://gallica.bnf.fr/iiif/ark:/12148/btv1b100357501/manifest.json
+F-Pn NAL 1535,https://gallica.bnf.fr/iiif/ark:/12148/btv1b100337650/manifest.json
+F-Pn NAL 1411,https://gallica.bnf.fr/iiif/ark:/12148/btv1b10033588d/manifest.json
 F-TOm 149,https://bvmm.irht.cnrs.fr/iiif/25704/manifest
 F-VAL 114,https://bvmm.irht.cnrs.fr/iiif/33956/manifest 
 GB-CCC Ms. 146,https://dms-data.stanford.edu/data/manifests/Parker/wy783rb3141/manifest.json


### PR DESCRIPTION
Closes #707. Several BNF iiif manifests were not loading with the `import_data iiif` command because the command requires an exact match between the manuscript siglum in `manifests.csv` and the siglum in the database. This PR updates `manifests.csv` so that the sigla there for BMF manuscripts matches the sigla used by CantusDB/Cantus Ultimus.