### PR TITLE
Remove edit functions from API endpoints

### DIFF
--- a/app/public/cantusdata/views/chant.py
+++ b/app/public/cantusdata/views/chant.py
@@ -3,13 +3,13 @@ from cantusdata.serializers.chant import ChantSerializer
 from rest_framework import generics
 
 
-class ChantList(generics.ListCreateAPIView):
+class ChantList(generics.ListAPIView):
     model = Chant
     queryset = Chant.objects.all()
     serializer_class = ChantSerializer
 
 
-class ChantDetail(generics.RetrieveUpdateDestroyAPIView):
+class ChantDetail(generics.RetrieveAPIView):
     model = Chant
     queryset = Chant.objects.all()
     serializer_class = ChantSerializer

--- a/app/public/cantusdata/views/concordance.py
+++ b/app/public/cantusdata/views/concordance.py
@@ -3,13 +3,13 @@ from cantusdata.serializers.concordance import ConcordanceSerializer
 from rest_framework import generics
 
 
-class ConcordanceList(generics.ListCreateAPIView):
+class ConcordanceList(generics.ListAPIView):
     model = Concordance
     queryset = Concordance.objects.all()
     serializer_class = ConcordanceSerializer
 
 
-class ConcordanceDetail(generics.RetrieveUpdateDestroyAPIView):
+class ConcordanceDetail(generics.RetrieveAPIView):
     model = Concordance
     queryset = Concordance.objects.all()
     serializer_class = ConcordanceSerializer

--- a/app/public/cantusdata/views/folio.py
+++ b/app/public/cantusdata/views/folio.py
@@ -4,7 +4,7 @@ from django.http import Http404
 from rest_framework import generics
 
 
-class FolioList(generics.ListCreateAPIView):
+class FolioList(generics.ListAPIView):
     model = Folio
     serializer_class = FolioSerializer
 
@@ -29,7 +29,7 @@ class FolioList(generics.ListCreateAPIView):
             return queryset[:1]  # Make sure we return only one element
 
 
-class FolioDetail(generics.RetrieveUpdateDestroyAPIView):
+class FolioDetail(generics.RetrieveAPIView):
     model = Folio
     queryset = Folio.objects.all()
     serializer_class = FolioSerializer

--- a/app/public/cantusdata/views/manuscript.py
+++ b/app/public/cantusdata/views/manuscript.py
@@ -8,7 +8,7 @@ from cantusdata.serializers.manuscript import (
 from cantusdata.renderers import templated_view_renderers
 
 
-class ManuscriptList(generics.ListCreateAPIView):
+class ManuscriptList(generics.ListAPIView):
     model = Manuscript
     queryset = Manuscript.objects.filter(public=True)
     serializer_class = ManuscriptListSerializer
@@ -16,7 +16,7 @@ class ManuscriptList(generics.ListCreateAPIView):
     renderer_classes = templated_view_renderers
 
 
-class ManuscriptDetail(generics.RetrieveUpdateDestroyAPIView):
+class ManuscriptDetail(generics.RetrieveAPIView):
     model = Manuscript
     queryset = Manuscript.objects.filter(public=True)
     serializer_class = ManuscriptSerializer


### PR DESCRIPTION
This PR changes the class inheritance for the `ChantList`, `ChantDetail`, `FolioList`, `FolioDetail`, `ConcordanceList`, `ConcordanceDetail`, `ManuscriptList` and `ManuscriptDetail` views. `*List` views used to inherit from Django Rest Framework's `ListCreateAPIView` which allowed for both GET and POST requests. `*Detail` views used to inherit from Django Rest Framework's `RetrieveUpdateDestroyAPIView` which allowed GET, PUT, PATCH, and DELETE requests. At this time, only GET requests are required on those endpoints, and other request types had been previously allowed without authentication or verification. The now inherit from `ListAPIView` and `RetrieveAPIView` which only provides GET requests.

This PR closes #721, where a complete inventory of Cantus Ultimus's API endpoints was also undertaken to verify which views allowed these types of edit requests.