### PR TITLE
Update links to CantusDB (cantus.waterloo.ca --> cantusdatabase.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Cantus Ultimus](http://cantus.simssa.ca/)
 
-Serving images on a website using [Apache Solr](http://lucene.apache.org/solr/), [Diva.js](https://ddmal.github.io/diva.js/) and the [CANTUS](http://cantusdatabase.org/) collection.
+Serving images on a website using [Apache Solr](http://lucene.apache.org/solr/), [Diva.js](https://ddmal.github.io/diva.js/) and the [CANTUS](https://cantusdatabase.org/) collection.
 
 The status of manuscripts served by Cantus Ultimus is available [here](#manuscript-inventory). Inclusion of additional manuscripts should be recorded there.
 
@@ -106,7 +106,7 @@ Using your admin credentials, verify that you are able to log into the admin dja
 
 When navigating through any of the tables in the admin interface (e.g., Manuscripts, Concordances, and Chants), they will appear to be empty.
 
-We can pre-populate the Concordances, Manuscripts, and Chants from the information available in the [Cantus Database](http://cantus.uwaterloo.ca/).
+We can pre-populate the Concordances, Manuscripts, and Chants from the information available in the [Cantus Database](https://cantusdatabase.org/).
 
 The scripts to populate the database are included in the repository. Head back to the terminal where you created the admin user account.
 

--- a/app/public/cantusdata/helpers/scrapers/genre.py
+++ b/app/public/cantusdata/helpers/scrapers/genre.py
@@ -57,7 +57,7 @@ class GenreScraper(HTMLParser):
                 self.value = data
 
 
-genre_url = "http://cantus.uwaterloo.ca/genre"
+genre_url = "https://cantusdatabase.org/genre"
 contents = urllib.request.urlopen(genre_url).read().decode("utf-8")
 parser = GenreScraper()
 parser.feed(contents)

--- a/app/public/cantusdata/helpers/scrapers/genre.py
+++ b/app/public/cantusdata/helpers/scrapers/genre.py
@@ -19,6 +19,7 @@ class GenreScraper(HTMLParser):
     def flush(self):
         self.is_field_name = False
         self.is_field_description = False
+        self.row_cell_count = 0
         self.key = ""
         self.value = ""
         self.dictionary = {}
@@ -29,12 +30,12 @@ class GenreScraper(HTMLParser):
         return ret
 
     def handle_starttag(self, tag, attrs):
-        field_name = ("class", "views-field views-field-name")
-        field_description = ("class", "views-field views-field-description")
+        if tag == "tr":
+            self.row_cell_count = 0
         if tag == "td":
-            if field_name in attrs:
+            if self.row_cell_count == 0:
                 self.is_field_name = True
-            elif field_description in attrs:
+            elif self.row_cell_count == 1:
                 self.is_field_description = True
 
     def handle_endtag(self, tag):
@@ -47,6 +48,7 @@ class GenreScraper(HTMLParser):
                     self.dictionary[self.key.strip("[]")] = self.value
                     self.key = ""
                     self.value = ""
+            self.row_cell_count += 1
 
     def handle_data(self, data):
         if self.is_field_name:
@@ -54,7 +56,7 @@ class GenreScraper(HTMLParser):
                 self.key = data
         if self.is_field_description:
             if not data.isspace():
-                self.value = data
+                self.value = data.strip()
 
 
 genre_url = "https://cantusdatabase.org/genres"

--- a/app/public/cantusdata/helpers/scrapers/genre.py
+++ b/app/public/cantusdata/helpers/scrapers/genre.py
@@ -57,7 +57,7 @@ class GenreScraper(HTMLParser):
                 self.value = data
 
 
-genre_url = "https://cantusdatabase.org/genre"
+genre_url = "https://cantusdatabase.org/genres"
 contents = urllib.request.urlopen(genre_url).read().decode("utf-8")
 parser = GenreScraper()
 parser.feed(contents)

--- a/app/public/cantusdata/helpers/scrapers/manuscript.py
+++ b/app/public/cantusdata/helpers/scrapers/manuscript.py
@@ -148,7 +148,7 @@ class ManuscriptScraper(HTMLParser):
 
 
 def parse(url):
-    baseurl = "https://cantus.uwaterloo.ca"
+    baseurl = "https://cantusdatabase.org"
     # url is relative? -> join, url is absolute? -> nothing should change
     url = urljoin(baseurl, url)
     contents = urllib.request.urlopen(url).read().decode("utf-8")

--- a/app/public/cantusdata/helpers/scrapers/sources.py
+++ b/app/public/cantusdata/helpers/scrapers/sources.py
@@ -30,7 +30,7 @@ class SourcesScraper(HTMLParser):
                 self.dictionary[link] = title
 
 
-sources_url = "http://cantus.uwaterloo.ca/sources"
+sources_url = "https://cantusdatabase.org/sources"
 contents = urllib.request.urlopen(sources_url).read().decode("utf-8")
 parser = SourcesScraper()
 parser.feed(contents)

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -101,7 +101,6 @@ class SourceImporter:
         simplified once that is complete.
         """
         source_pg_url = f"{self.cdb_base_url}/source/{source_id}"
-        print(source_pg_url)
         source_pg_response = request.urlopen(source_pg_url).read().decode()
         source_pg_html = ProvenanceParser()
         source_pg_html.feed(source_pg_response)

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -101,6 +101,7 @@ class SourceImporter:
         simplified once that is complete.
         """
         source_pg_url = f"{self.cdb_base_url}/source/{source_id}"
+        print(source_pg_url)
         source_pg_response = request.urlopen(source_pg_url).read().decode()
         source_pg_html = ProvenanceParser()
         source_pg_html.feed(source_pg_response)
@@ -115,27 +116,15 @@ class SourceImporter:
         :return: a dictionary of Manuscript attributes
         """
         source_dict = {}
-        source_dict["id"] = source_json["vid"]
+        source_dict["id"] = source_json["id"]
         source_dict["name"] = source_json["title"]
-        if source_json["field_siglum"]:
-            source_dict["siglum"] = source_json["field_siglum"]["und"][0]["value"]
-        else:
-            source_dict["siglum"] = ""
-        if source_json["field_date"]:
-            source_dict["date"] = source_json["field_date"]["und"][0]["value"]
-        else:
-            source_dict["date"] = ""
+        source_dict["siglum"] = source_json.get("siglum", "")
+        source_dict["date"] = source_json.get("date", "")
         ## See documentation of the download_source_provenance method for details
         ## on these commented lines.
-        # if source_json["field_provenance"]:
-        #     source_dict["provenance"] = source_json["field_provenance"]["und"][0]["value"]
-        # else:
-        #     source_dict["provenance"] = ""
+        # source_dict["provenance"] = source_json.get("provenance","")
         source_dict["provenance"] = self.download_source_provenance(source_dict["id"])
-        if source_json["field_summary"]:
-            source_dict["description"] = source_json["field_summary"]["und"][0]["value"]
-        else:
-            source_dict["description"] = ""
+        source_dict["description"] = source_json.get("summary", "")
         return source_dict
 
     def get_source_data(self, source_id):

--- a/app/public/cantusdata/management/commands/import_data.py
+++ b/app/public/cantusdata/management/commands/import_data.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
     @transaction.atomic
     def import_manuscript_data(self, **options):
         self.stdout.write("Starting manuscript import process.")
-        cdb_base_url = "https://cantusdatabase.org/"
+        cdb_base_url = "https://cantusdatabase.org"
         source_importer = SourceImporter(cdb_base_url)
         source_ids = source_importer.request_source_ids()
         i = 0

--- a/app/public/cantusdata/management/commands/import_data.py
+++ b/app/public/cantusdata/management/commands/import_data.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
     @transaction.atomic
     def import_manuscript_data(self, **options):
         self.stdout.write("Starting manuscript import process.")
-        cdb_base_url = "https://cantus.uwaterloo.ca/"
+        cdb_base_url = "https://cantusdatabase.org/"
         source_importer = SourceImporter(cdb_base_url)
         source_ids = source_importer.request_source_ids()
         i = 0

--- a/app/public/cantusdata/management/commands/normalize_chant_csv.py
+++ b/app/public/cantusdata/management/commands/normalize_chant_csv.py
@@ -8,7 +8,7 @@ W_REGEX = re.compile(r"^(\d+)w$")
 
 
 class Command(BaseCommand):
-    """Normalize chants exported from http://cantus.uwaterloo.ca for compatibility with the chant import script"""
+    """Normalize chants exported from Cantus Database for compatibility with the chant import script"""
 
     args = "filename.csv"
 

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -241,7 +241,7 @@ export default Marionette.ItemView.extend({
 		var formattedVolpiano = parseVolpianoSyllables(text, volpiano);
 		this.model.set('volpiano', formattedVolpiano);
 		var cdb_uri = this.model.get('cdb_uri');
-		this.model.set({ 'cdb_link_url': 'https://cantus.uwaterloo.ca/node/' + cdb_uri });
+		this.model.set({ 'cdb_link_url': 'https://cantusdatabase.org/node/' + cdb_uri });
 	},
 	ui : {
 		volpianoSyllables: ".volpiano-syllable",

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -244,7 +244,7 @@ export default Marionette.ItemView.extend({
 		var formattedVolpiano = parseVolpianoSyllables(text, volpiano);
 		this.model.set('volpiano', formattedVolpiano);
 		var cdb_uri = this.model.get('cdb_uri');
-		this.model.set({ 'cdb_link_url': 'https://cantusdatabase.org/node/' + cdb_uri });
+		this.model.set({ 'cdb_link_url': 'https://cantusdatabase.org/chant/' + cdb_uri });
 		manuscriptChannel.on('chantAccordion:click',this.stopChantAudio, this);
 	},
 	ui : {


### PR DESCRIPTION
This PR changes all urls for CantusDB in the Cantus Ultimus code base from cantus.waterloo.ca to cantusdatabase.org. Also uses https rather than http for all requests to CantusDB.

Although the `/genre` page redirects to `/genres` on NewCantus, this PR changes the url in `helpers/scrapers/genre.py` to go directly to `/genres` rather than through the redirect.

Closes #761 along with https://github.com/DDMAL/cantus-staticpages/pull/5