### PR TITLE
Stop chant audio when chant is changed

### DIFF
--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantItemView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantItemView.js
@@ -1,7 +1,10 @@
 import Marionette from 'marionette';
+import Backbone from 'backbone';
 import ChantRecordView from './ChantRecordView';
 
 import template from './chant-item.template.html';
+
+var manuscriptChannel = Backbone.Radio.channel('manuscript');
 
 /**
  * A panel containing chant information
@@ -18,12 +21,14 @@ export default Marionette.LayoutView.extend({
     },
 
     ui: {
-        collapse: '.collapse'
+        collapse: '.collapse',
+        panelHeading: '.panel-heading'
     },
 
     events: {
         'hide.bs.collapse': '_triggerFoldChant',
-        'show.bs.collapse': '_triggerUnfoldChant'
+        'show.bs.collapse': '_triggerUnfoldChant',
+        'click @ui.panelHeading': 'onChantAccordionClick'
     },
 
     collapseContent: function ()
@@ -74,5 +79,13 @@ export default Marionette.LayoutView.extend({
     _triggerUnfoldChant: function ()
     {
         this.trigger('unfold:chant');
+    },
+
+    /**
+     * Trigger an event to stop any audio that is playing
+        */
+    onChantAccordionClick: function ()
+    {
+        manuscriptChannel.trigger('chantAccordion:click');
     }
 });

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -1,3 +1,4 @@
+import Backbone from 'backbone';
 import Marionette from 'marionette';
 
 import { parseVolpianoSyllables } from 'utils/VolpianoDisplayHelper';
@@ -5,6 +6,8 @@ import { parseVolpianoSyllables } from 'utils/VolpianoDisplayHelper';
 import template from './chant-record.template.html';
 
 import { MIDI }  from 'utils/midi-player/midiPlayer.js';
+
+var manuscriptChannel = Backbone.Radio.channel('manuscript');
 
 MIDI.audioDetect(function (supports){
 	MIDI.supports = supports;
@@ -242,6 +245,7 @@ export default Marionette.ItemView.extend({
 		this.model.set('volpiano', formattedVolpiano);
 		var cdb_uri = this.model.get('cdb_uri');
 		this.model.set({ 'cdb_link_url': 'https://cantus.uwaterloo.ca/node/' + cdb_uri });
+		this.listenTo(manuscriptChannel, 'change:chant', this.chantChanged);
 	},
 	ui : {
 		volpianoSyllables: ".volpiano-syllable",
@@ -260,5 +264,10 @@ export default Marionette.ItemView.extend({
 	},
 	stop: function(){
 		audioStopReset(MIDI);
+	},
+	chantChanged: function(){
+		if (MIDI.getContext().state === "running"){
+			audioStopReset(MIDI);
+		}
 	}
 });

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/ChantRecordView.js
@@ -245,7 +245,7 @@ export default Marionette.ItemView.extend({
 		this.model.set('volpiano', formattedVolpiano);
 		var cdb_uri = this.model.get('cdb_uri');
 		this.model.set({ 'cdb_link_url': 'https://cantus.uwaterloo.ca/node/' + cdb_uri });
-		this.listenTo(manuscriptChannel, 'change:chant', this.chantChanged);
+		manuscriptChannel.on('chantAccordion:click',this.stopChantAudio, this);
 	},
 	ui : {
 		volpianoSyllables: ".volpiano-syllable",
@@ -265,9 +265,12 @@ export default Marionette.ItemView.extend({
 	stop: function(){
 		audioStopReset(MIDI);
 	},
-	chantChanged: function(){
+	stopChantAudio: function(){
 		if (MIDI.getContext().state === "running"){
 			audioStopReset(MIDI);
 		}
+	},
+	onDestroy: function(){
+		manuscriptChannel.off('chantAccordion:click',this.stopChantAudio, this);
 	}
 });


### PR DESCRIPTION
Closes #767. Playing audio is stopped when the chant is changed by:

a. Closing the open chant accordion panel;
b. Opening a new chant accordion panel; or
c. Scrolling to a new image.