### PR TITLE
Handle quotation marks in search strings and adjust query result header styling

### DIFF
--- a/nginx/public/node/frontend/public/css/styles.scss
+++ b/nginx/public/node/frontend/public/css/styles.scss
@@ -679,3 +679,8 @@ html.js {
         word-wrap: break-word;
     }
 }
+
+.displayed-query{
+    color: #c2342e;
+    font-weight: bold;
+}

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
@@ -101,7 +101,18 @@ export default Marionette.Object.extend({
         // Modify query returned by solr so it is ready for display.
         // Remove escaping backslashes from the displayed string.
         let query = this.searchParameters.get('query');
-        let displayedQuery = (fieldName === "volpiano" || fieldName === "volpiano_literal") ? query.replaceAll("\\-", "-") : query;
+        let displayedQuery;
+        switch (fieldName){
+            case "volpiano":
+            case "volpiano_literal":
+                displayedQuery = query.replaceAll("\\-", "-");
+                break;
+            case "mode":
+                displayedQuery = query.join(", ");
+                break;
+            default:
+                displayedQuery = query;
+        }
         return {
             fieldName: fieldName,
             query: query,

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/SearchInputView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/SearchInputView.js
@@ -66,6 +66,12 @@ export default Marionette.ItemView.extend({
             // escaped hyphens in the query string.
             searchInput = searchInput.replaceAll("-","\\-");
         }
+        // Handle quotations in text field searches. Solr errors if quotation marks
+        // are not closed. If the search string contains an odd number of quotation
+        // marks, add a quotation mark to the end of the string.
+        if (["all","feast","genre","office"].includes(searchField)){
+            (searchInput.split('"').length - 1) % 2 === 1 ? searchInput += '"' : null;
+        }
         // FIXME(wabain): While this class needs to take a SearchInput model so it can initially
         // be rendered, we're not actually updating that model here - we're just triggering
         // an event which will cause the appropriate changes to propagate. That's kind of

--- a/nginx/public/node/frontend/public/js/app/search/search-result-heading.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/search-result-heading.template.html
@@ -1,7 +1,7 @@
-<p class="h4"><i><%- numFound %> <%- numFound === 1 ? 'result' : 'results' %> for query 
+<p class="h5"><i><%- numFound %> <%- numFound === 1 ? 'result' : 'results' %> for query:</i>
 <% if (fieldName == "volpiano" || fieldName == "volpiano_literal") { %>
-</i><span class = "volpiano">1-<%- displayedQuery %></span>
+<span class = "volpiano">1-<%- displayedQuery %></span>
 <% } else { %>
-"<%- query %>"</i>
+<span class="displayed-query"><%- displayedQuery %></span>
 <% } %>
 </p>


### PR DESCRIPTION
This PR:

- Adds closing quotations to the end of search strings if there is an unclosed quotation in the user-entered search string. Solr errors when there are unclosed quotations (ie. an odd number of quotation marks in the query string). In this case we assume that that user is either still typing, so we close the quotation to show intermediate results, or that the user forgot to close the quotation. 
- Previously, the searched-for query string was enclosed in quotation marks. But, since the search string itself may contain quotation marks, we change the styling. 
Old style:
![image](https://github.com/DDMAL/cantus/assets/11023634/7555dcf1-efec-47eb-9007-d57430d4b8c4)
New style:
![image](https://github.com/DDMAL/cantus/assets/11023634/f0e85b27-757f-474e-be1e-41fe0a2bb29b)
- Modifies how we display the query for mode searches by adding a space between modes when multiple modes are searched.
Old style:
![image](https://github.com/DDMAL/cantus/assets/11023634/7218db31-7971-4271-8bcb-6c0bf54fcc72)
New style:
![image](https://github.com/DDMAL/cantus/assets/11023634/01bf7263-b268-4ba4-ad63-3c35ca76dc6a)


Closes #766.