### PR TITLE
Add CSRF_TRUSTED_ORIGINS to settings.py

### DIFF
--- a/app/public/cantusdata/settings.py
+++ b/app/public/cantusdata/settings.py
@@ -167,6 +167,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 SESSION_COOKIE_SECURE = is_production
 CSRF_COOKIE_SECURE = is_production
+CSRF_TRUSTED_ORIGINS = ["https://cantus.simssa.ca", "https://cantus.staging.simssa.ca"]
 
 SECURE_HSTS_SECONDS = 86400
 SECURE_HSTS_INCLUDE_SUBDOMAINS = is_production


### PR DESCRIPTION
In getting Release 3.2-0.11.3 working on the staging server, I discovered that with our upgrade to Django 4, there were changes to Django's CSRF protection that require the `CSRF_TRUSTED_ORIGINS` setting in our case. This PR adds that setting. See https://docs.djangoproject.com/en/4.2/releases/4.0/#csrf-trusted-origins-changes-4-0.