### PR TITLE
Implement minor UI fixes

### DIFF
--- a/nginx/public/node/frontend/public/css/styles.scss
+++ b/nginx/public/node/frontend/public/css/styles.scss
@@ -334,6 +334,9 @@ body.propagate-height {
 .modal-content {
     height: 100%;
 }
+.modal-header{
+    min-height:auto;
+}
 
 #manuscript-data-container {
     // Relative-position the container so that percentage-based dimensions are calculated relative to it

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
@@ -34,8 +34,8 @@
 <% if (finalis) { %>
 <p><b>Finalis: </b> <%= finalis %></p>
 <% } %>
-<hr/>
 <% if (full_text) { %>
+<hr/>
 <h5>Full Text</h5>
 <%= full_text %>
 <% } %>


### PR DESCRIPTION
Closes some minor outstanding UI bugs.

- Closes #781. If a chant has neither full text nor volpiano available, no horizontal dividing line is displayed in the chant detail panel.

Before: 
<img width="547" alt="image" src="https://github.com/DDMAL/cantus/assets/11023634/289d0b2f-362d-4f5c-b3ff-ebf6c693bcbd">

After: 
<img width="549" alt="image" src="https://github.com/DDMAL/cantus/assets/11023634/ab6b2635-4a70-4ad3-a88e-9b3ec407fca6">


- Closes #739. The horizontal divider between modal headers and contents is now stationary.
Before - notice divline running through "Search"
<img width="719" alt="image" src="https://github.com/DDMAL/cantus/assets/11023634/63aef571-9a51-4e33-83a6-11effbc05cf8">

After:
<img width="718" alt="image" src="https://github.com/DDMAL/cantus/assets/11023634/920f0d9b-028a-4652-818d-0d360a1cb98a">
