### PR TITLE
Redirect to ManuscriptListView when manuscript is not found

### DIFF
--- a/app/public/cantusdata/templates/missing_manuscript_redirect.html
+++ b/app/public/cantusdata/templates/missing_manuscript_redirect.html
@@ -6,7 +6,7 @@
     <div class="row" style="padding-top:20vh;padding-bottom:20vh">
         <div class="col-lg-12">
             <p class="text-center">This manuscript has been moved.</p>
-            <p class="text-center">You can find it on <a href="{% url 'manuscript-list' %}">the Manuscripts page</a>.</p>
+            <p class="text-center">You can find it on the <a href="{% url 'manuscript-list' %}">Manuscripts</a> page.</p>
         </div>
     </div>
 

--- a/app/public/cantusdata/templates/missing_manuscript_redirect.html
+++ b/app/public/cantusdata/templates/missing_manuscript_redirect.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<div class="container">
+    <div class="row" style="padding-top:20vh;padding-bottom:20vh">
+        <div class="col-lg-12">
+            <p class="text-center">This manuscript has been moved.</p>
+            <p class="text-center">You can find it on <a href="{% url 'manuscript-list' %}">the Manuscripts page</a>.</p>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-lg-12">
+            <img class="center-block logos"
+                 alt="Combined logos: Social Sciences and Humanities Research Council of Canada;
+                 Schulich School of Music, McGill University; Distributed Digital Music Archives and Libraries Lab;
+                 Centre for Interdisciplinary Research in Music Media and Technology; Fonds de recherche du Québec
+                 – Société et culture" src="/static/img/all_logos_sm.png">
+        </div>
+
+    </div>
+</div>
+    
+{% endblock %}

--- a/app/public/cantusdata/test/core/views/test_manuscript.py
+++ b/app/public/cantusdata/test/core/views/test_manuscript.py
@@ -33,7 +33,7 @@ class ManuscriptViewTestCase(APITransactionTestCase):
         if not manuscript:
             self.fail("No manuscripts loading!")
         response = self.client.get("/manuscript/{0}/".format(manuscript.id))
-        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def tearDown(self):
         Chant.objects.all().delete()

--- a/app/public/cantusdata/test/core/views/test_manuscript.py
+++ b/app/public/cantusdata/test/core/views/test_manuscript.py
@@ -33,7 +33,7 @@ class ManuscriptViewTestCase(APITransactionTestCase):
         if not manuscript:
             self.fail("No manuscripts loading!")
         response = self.client.get("/manuscript/{0}/".format(manuscript.id))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
     def tearDown(self):
         Chant.objects.all().delete()

--- a/app/public/cantusdata/views/manuscript.py
+++ b/app/public/cantusdata/views/manuscript.py
@@ -5,9 +5,9 @@ from cantusdata.serializers.manuscript import (
     ManuscriptListSerializer,
 )
 from cantusdata.renderers import templated_view_renderers
-from django.http import Http404, HttpResponseRedirect
+from django.http import Http404, HttpResponseNotFound
+from django.shortcuts import render
 from rest_framework.response import Response
-from django.urls import reverse
 
 
 class ManuscriptList(generics.ListAPIView):
@@ -39,4 +39,6 @@ class ManuscriptDetail(generics.RetrieveAPIView):
             serializer = self.get_serializer(instance)
             return Response(serializer.data)
         except Http404:
-            return HttpResponseRedirect(reverse("manuscript-list"))
+            return HttpResponseNotFound(
+                render(request, "missing_manuscript_redirect.html")
+            )

--- a/app/public/cantusdata/views/manuscript.py
+++ b/app/public/cantusdata/views/manuscript.py
@@ -28,9 +28,9 @@ class ManuscriptDetail(generics.RetrieveAPIView):
     def retrieve(self, request, *args, **kwargs):
         """
         Overrides the default retrieval method
-        to return a redirect to the manuscript list
-        page if the manuscript is not found. Implemented
-        to prevent 404 errors from links to specific manuscripts
+        to return a custom 404 page if the manuscript
+        is not found. Implemented to prevent generic 
+        404 errors from links to specific manuscripts
         made before manuscript ids were stable.
         """
 

--- a/app/public/cantusdata/views/manuscript.py
+++ b/app/public/cantusdata/views/manuscript.py
@@ -1,11 +1,13 @@
 from rest_framework import generics
-from django.views import generic
 from cantusdata.models.manuscript import Manuscript
 from cantusdata.serializers.manuscript import (
     ManuscriptSerializer,
     ManuscriptListSerializer,
 )
 from cantusdata.renderers import templated_view_renderers
+from django.http import Http404, HttpResponseRedirect
+from rest_framework.response import Response
+from django.urls import reverse
 
 
 class ManuscriptList(generics.ListAPIView):
@@ -22,3 +24,19 @@ class ManuscriptDetail(generics.RetrieveAPIView):
     serializer_class = ManuscriptSerializer
     template_name = "require.html"
     renderer_classes = templated_view_renderers
+
+    def retrieve(self, request, *args, **kwargs):
+        """
+        Overrides the default retrieval method
+        to return a redirect to the manuscript list
+        page if the manuscript is not found. Implemented
+        to prevent 404 errors from links to specific manuscripts
+        made before manuscript ids were stable.
+        """
+
+        try:
+            instance = self.get_object()
+            serializer = self.get_serializer(instance)
+            return Response(serializer.data)
+        except Http404:
+            return HttpResponseRedirect(reverse("manuscript-list"))

--- a/app/public/cantusdata/views/manuscript.py
+++ b/app/public/cantusdata/views/manuscript.py
@@ -29,7 +29,7 @@ class ManuscriptDetail(generics.RetrieveAPIView):
         """
         Overrides the default retrieval method
         to return a custom 404 page if the manuscript
-        is not found. Implemented to prevent generic 
+        is not found. Implemented to prevent generic
         404 errors from links to specific manuscripts
         made before manuscript ids were stable.
         """


### PR DESCRIPTION
Overrides the default `retrieve` method of the ManuscriptDetailView class so that when a manuscript with the requested ID is not found, a custom `404` page is returned that directs users to the ManuscriptListView (see below).

As mentioned in the function's comment, this is meant to mitigate cases where a link to a specific manuscript was published before manuscripts in Cantus Ultimus had stable ID's.

Closes #802 


Custom 404 Page
https://user-images.githubusercontent.com/11023634/284639619-89ed0747-a41a-46ae-82f8-a69cdda4b741.png