### PR TITLE
Add IIIF attribution and licence information to "Manuscript Info" sidebar

### DIFF
--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/DivaView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/DivaView.js
@@ -27,7 +27,8 @@ export default Marionette.ItemView.extend({
     {
         _.bindAll(this, 'propagateFolioChange', 'onViewerLoad', 'setImageURI',
             'paintBoxes', 'updatePageAlias', 'gotoInputPage',
-            'getPageWhichMatchesAlias', 'onDocLoad', 'showPageSuggestions');
+            'getPageWhichMatchesAlias', 'onDocLoad', 'showPageSuggestions', 
+            'onManifestLoad');
 
         this.divaEventHandles = [];
 
@@ -108,6 +109,7 @@ export default Marionette.ItemView.extend({
         this.onDivaEvent("ViewerDidLoad", this.propagateFolioChange);
         this.onDivaEvent("VisiblePageDidChange", this.propagateFolioChange);
         this.onDivaEvent("DocumentDidLoad", this.onDocLoad);
+        this.onDivaEvent("ManifestDidLoad", this.onManifestLoad);
     },
 
     /**
@@ -309,6 +311,32 @@ export default Marionette.ItemView.extend({
 
         // Change initial view to document view
         this.divaInstance.changeView('document');
+    },
+
+    /**
+     * Once the manifest is loaded, grab any attribution and rights information
+     * contained in the manifest and update the DOM to display it.
+     * NOTE: Diva contains a plug-in ("IIIFMetadata") that could theoretically
+     * be used to collect and show this data, but it errors if this data is
+     * improperly formatted in the IIIF, so we introduce this here to tolerate
+     * these cases.
+     * NOTE: At the moment, we only support the IIIF 2 API, since Diva only
+     * supports that version.
+     **/
+    onManifestLoad: function (manifest){
+        var attribution = manifest.attribution;
+        var logo = manifest.logo;
+        if (typeof logo === "object") {
+            var logo_url = logo['@id'];
+        } else {
+            var logo_url = logo;
+        }
+        var licence = manifest.license;
+        this.imageAttributionMetadata = {
+            imageAttribution: attribution,
+            imageLogoUrl: logo_url,
+            imageLicence: licence
+        };
     },
 
     /** Do some awkward manual manipulation of the toolbar */

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/ManuscriptDetailPageView.js
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/ManuscriptDetailPageView.js
@@ -133,6 +133,8 @@ export default Marionette.LayoutView.extend({
 
             $(manuscriptInfoButton).on('click', this._showInfoSidenav.bind(this));
             manuscriptInfo.appendTo(this.ui.toolbarRow.find('.diva-tools-right'));
+
+            this.model.set(divaView.imageAttributionMetadata);
         });
 
         // Initialize the search view

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/manuscript-info.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/manuscript-info.template.html
@@ -9,8 +9,8 @@
         <dt>Provenance</dt>
         <dd><%= provenance %></dd>
         <% if (description) { %>
-        <dt>Description</dt>
-        <dd><pre class="preformatted-text"><%= description %></pre></dd>
+            <dt>Description</dt>
+            <dd><pre class="preformatted-text"><%= description %></pre></dd>
         <% } %>
     </dl>
 
@@ -18,19 +18,18 @@
         <h3 class="h4">Image Rights</h3>
         <% if (imageAttribution ) { %>
             <div>
-            <%= imageAttribution %></dd>
+                <%= imageAttribution %>
             </div>
         <% } %>
         <% if (imageLogoUrl) { %>
             <div>
-            <img src="<%= imageLogoUrl %>" alt="Logo of the image source institution" style="max-width: 300px; max-height: 100px; margin-top: 8px; margin-bottom: 8px;"/>
+                <img src="<%= imageLogoUrl %>" alt="Logo of the image source institution" style="max-width: 300px; max-height: 100px; margin-top: 8px; margin-bottom: 8px;"/>
             </div>
         <% } %>
         <% if (imageLicence) { %>
             <div>
-            <a href="<%= imageLicence %>" target="_blank">Click for licence information.</a>
-        </div>
+                <a href="<%= imageLicence %>" target="_blank">Click for licence information.</a>
+            </div>
         <% } %>
     <% } %>
-
 </div>

--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/manuscript-info.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/manuscript-info.template.html
@@ -13,4 +13,24 @@
         <dd><pre class="preformatted-text"><%= description %></pre></dd>
         <% } %>
     </dl>
+
+    <% if (imageAttribution || imageLicence || imageLogoUrl) { %>
+        <h3 class="h4">Image Rights</h3>
+        <% if (imageAttribution ) { %>
+            <div>
+            <%= imageAttribution %></dd>
+            </div>
+        <% } %>
+        <% if (imageLogoUrl) { %>
+            <div>
+            <img src="<%= imageLogoUrl %>" alt="Logo of the image source institution" style="max-width: 300px; max-height: 100px; margin-top: 8px; margin-bottom: 8px;"/>
+            </div>
+        <% } %>
+        <% if (imageLicence) { %>
+            <div>
+            <a href="<%= imageLicence %>" target="_blank">Click for licence information.</a>
+        </div>
+        <% } %>
+    <% } %>
+
 </div>


### PR DESCRIPTION
This PR adds information about the source and licensing for images used on Cantus Ultimus to the "Manuscript Info" sidebar on the Manuscript Detail view. 

IIIF manifests conforming to the Presentation API v 2 may have `attribution`, `license`, and `logo` attributes that contain an attribution statement, a link to image licensing information, and a link to a logo of the providing institution, respectively. The contents of the `attribution` attribute must be shown, while showing the other two are optional. This PR opts to show any of the three that are available. 

The associated issue #786 references a `requiredStatement` field. This was introduced with the IIIF Presentation API v 3. No manifests currently on Cantus Ultimus use v 3 of the API, and Diva does not currently support v 3, so I've opted not to support `requiredStatement` here. In the even that support of v 3 of the Presentation API is necessary, then changes to how image attribution is shown will need to occur.

Closes #786. 

Screenshots showing how this looks on a few different manuscripts:
![image](https://github.com/DDMAL/cantus/assets/11023634/14c66fc1-42e2-4c5c-ad47-b3e2f82aa9ba)
![image](https://github.com/DDMAL/cantus/assets/11023634/cd801fa8-4b16-4c9c-b313-28f300d5559f)
![image](https://github.com/DDMAL/cantus/assets/11023634/42dd8156-97a5-44dc-9c89-1f0919deddc0)
