### PR TITLE
Update nginx.conf for cantaloupe redirects (without nested location blocks)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -30,6 +30,10 @@ http {
     server app:8001 fail_timeout=0;
   }
 
+  upstream cantaloupe {
+    server cantaloupe:8182;
+  }
+  
   server {
     # if no Host match, close the connection to prevent host spoofing
     listen 80 default_server;
@@ -50,18 +54,14 @@ http {
     # path for static files
     root /code;
 
-    location /iiif {
+    location ~ /iiif(/2)?(.*) {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Host $http_host;
      
       proxy_redirect off;
-      
-      location /iiif/2 {
-          proxy_pass http://cantaloupe:8182/iiif/2;
-      }
 
-      proxy_pass http://cantaloupe:8182/iiif/2;
+      proxy_pass http://cantaloupe/iiif/2$2;
     }
 
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -54,7 +54,7 @@ http {
     # path for static files
     root /code;
 
-    location ~ /iiif(/2)?(.*) {
+    location ~ ^/iiif(/2)?(.*) {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Host $http_host;


### PR DESCRIPTION
Updates `nginx.conf` to remove the need for nested location blocks. 

Requests to the Cantus Ultimus server are directed to cantaloupe if of the form `cantus[.staging].simssa.ca/iiif` or `cantus[.staging].simssa.ca/iiif/2`. The first case (sans `/2`) captures the case of uri's to the Cantus Ultimus IIIF server (for example, those we've put in the Gottschalk reconstruction's manifest). The second case (with `/2`) captures internal redirects generated by cantaloupe.