### PR TITLE
Use CantusDB's provenance json api during source import process

### DIFF
--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -1,57 +1,5 @@
 from urllib import request
 import json
-from html.parser import HTMLParser
-
-
-class ProvenanceParser(HTMLParser):
-    """
-    ProvenanceParser extracts the short provenance name from a CantusDB source
-    page (/source/id-of-source/).
-
-    provenance_div flags whether the parser has reached the div containing the
-    provenance text.
-
-    provenance_a flags whether the parser has reached the anchor tag that contains
-    the provenance text.
-    """
-
-    def __init__(self):
-        super().__init__()
-        self.provenance_div = False
-        self.provenance_a = False
-        self.provenance = ""
-
-    def handle_starttag(self, tag, attrs):
-        """
-        While parsing the html:
-        1. determine whether a div tag encountered by the parser has the unique
-        class attributes assigned to the div that contains provenance data. If
-        this div is encountered, the provenance_div flag is set to True.
-        2. if a anchor tag is encountered within this div tag, set the
-        provenance_a flag to True.
-        """
-        if tag == "div":
-            if ("class", "views-field views-field-field-provenance-tax") in attrs:
-                self.provenance_div = True
-        if tag == "a":
-            if self.provenance_div:
-                self.provenance_a = True
-
-    def handle_endtag(self, tag):
-        """
-        Once provenance data has been extracted, set the flags to False
-        """
-        if self.provenance_a:
-            self.provenance_div = False
-            self.provenance_a = False
-
-    def handle_data(self, data):
-        """
-        Extract the provenance data when provenance_a has been triggered.
-        """
-        if self.provenance_a:
-            self.provenance = data
-
 
 class SourceImporter:
     """
@@ -90,21 +38,13 @@ class SourceImporter:
 
     def download_source_provenance(self, source_id):
         """
-        The current Old CantusDB API endpoints do not provide
-        a method for obtaining Provenance metadata (the text returned
-        by the API in the provenance field contains more extensive notes
-        on the source provenance, but not the shorter designation that is
-        displayed publicly in CantusDB and on Cantus Ultimus). As such, this
-        method extracts this source provenance from CantusDB html. Incorporating
-        this into CantusDB's API is an open issue
-        (see https://github.com/DDMAL/CantusDB/issues/564), so this will be
-        simplified once that is complete.
+        Use Cantus Database's provenance export API to download the provenance
+        name for a given source.
         """
-        source_pg_url = f"{self.cdb_base_url}/source/{source_id}"
-        source_pg_response = request.urlopen(source_pg_url).read().decode()
-        source_pg_html = ProvenanceParser()
-        source_pg_html.feed(source_pg_response)
-        return source_pg_html.provenance
+        prov_json_url = f"{self.cdb_base_url}/provenance/{source_id}/json"
+        prov_json_response = request.urlopen(prov_json_url).read()
+        prov_json = json.loads(prov_json_response)
+        return prov_json["name"]
 
     def extract_source_data(self, source_json):
         """
@@ -119,10 +59,8 @@ class SourceImporter:
         source_dict["name"] = source_json["title"]
         source_dict["siglum"] = source_json.get("siglum", "")
         source_dict["date"] = source_json.get("date", "")
-        ## See documentation of the download_source_provenance method for details
-        ## on these commented lines.
-        # source_dict["provenance"] = source_json.get("provenance","")
-        source_dict["provenance"] = self.download_source_provenance(source_dict["id"])
+        provenance_id = source_json.get("provenance_id", "")
+        source_dict["provenance"] = self.download_source_provenance(provenance_id)
         source_dict["description"] = source_json.get("summary", "")
         return source_dict
 

--- a/app/public/cantusdata/helpers/source_importer.py
+++ b/app/public/cantusdata/helpers/source_importer.py
@@ -1,6 +1,7 @@
 from urllib import request
 import json
 
+
 class SourceImporter:
     """
     Imports sources from CantusDB by way of its APIs.


### PR DESCRIPTION
Revises the `SourceImporter` helper used during the source import process to use Cantus DB's new provenance api to get the name of a source's provenance. This eliminates the need to parse html from CantusDB to get Provenance name, and therefore now at any point in the source import process.

Closes #808.