### PR TITLE
Add docker volume for solr index; modify static files volume

### DIFF
--- a/app/public/cantusdata/settings.py
+++ b/app/public/cantusdata/settings.py
@@ -132,7 +132,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/dev/howto/static-files/
 
-STATIC_URL = "/static/django/"
+STATIC_URL = "/static/"
 MEDIA_URL = "/media/"
 MEDIA_URL_NEUMEEDITOR = "/neumeeditor/media/"
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -71,7 +71,7 @@ http {
 
     location / {
       # checks for static file, if not found proxy to app
-      try_files $uri @proxy_to_app;
+      try_files $uri django/$uri @proxy_to_app;
     }
 
     location @proxy_to_app {


### PR DESCRIPTION
This PR makes two changes to docker volumes:

1. It adds a docker volume that contains the solr index files. This allows us to persist the index between container builds, rather than re-indexing every time the container is built.
2. It reworks the static files volume that is used to share static files managed by django with the `nginx` container. Django-managed static files are now mapped to `/code/static/django` in the `nginx` container rather than `/code/static`. Node-managed static files are still mapped to `/code/static`. This means that any existing files in the volume persisted from build to build do no overwrite changes to static files introduced in a build of the `nginx` container. This fixes #841.