### PR TITLE
Make `manuscript` column first in multi-manuscript search results

### DIFF
--- a/nginx/public/node/frontend/public/js/app/search/chant-search/SearchResultCollectionView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/SearchResultCollectionView.js
@@ -57,6 +57,11 @@ export default Marionette.CompositeView.extend({
 
         this.listenTo(this.searchParameters, 'change:sortBy change:reverseSort', this._triggerSortingChanged);
         this.listenTo(this.searchParameters, 'change:query change:field', this._resetScrolling);
+
+        // Show manuscript column if additional fields requested in search
+        // includes the manuscript (in other words, if we are doing a 
+        // cross-manuscript search)
+        this.showManuscript = _.some(this.getOption("infoFields"), field => field.type === 'manuscript');
     },
 
     childViewOptions: function ()
@@ -64,7 +69,8 @@ export default Marionette.CompositeView.extend({
         return {
             searchType: this.searchParameters.get('field'),
             query: this.searchParameters.get('query'),
-            infoFields: this.getOption('infoFields')
+            infoFields: this.getOption('infoFields'),
+            showManuscript: this.showManuscript
         };
     },
 
@@ -215,7 +221,8 @@ export default Marionette.CompositeView.extend({
     templateHelpers: function()
     {
         return {
-            infoFields: _.toArray(this.getOption('infoFields'))
+            infoFields: _.toArray(this.getOption('infoFields')),
+            showManuscript: this.showManuscript
         };
     }
 });

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/SearchResultItemView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/SearchResultItemView.js
@@ -117,6 +117,7 @@ export default Marionette.ItemView.extend({
 
         return {
             infoFields: infoFields,
+            showManuscript: this.getOption('showManuscript'),
             searchType: searchType,
             result: this.model.getFormattedData(searchType, query),
             isVolpianoSearch: searchType === 'volpiano' || searchType === 'volpiano_literal',

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/search-result-collection.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/search-result-collection.template.html
@@ -2,6 +2,12 @@
     <table class="table table-condensed result-list child-container">
         <thead>
             <tr>
+                <% if (showManuscript) { %>
+                <th> 
+                    <a href="#">Manuscript</a>
+                    <span class="search-caret"></span>
+                </th>
+                <% } %>
                 <th>
                     <a href="#">Folio</a>
                     <span class="search-caret"></span>
@@ -13,10 +19,12 @@
                 </th>
 
                 <% _.forEach(infoFields, function (field) { %>
+                <% if (field.type != 'manuscript') { %>
                 <th>
                     <a href="#"><%= field.name %></a>
                     <span class="search-caret"></span>
                 </th>
+                <% } %>
                 <% }); %>
             </tr>
         </thead>

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/search-result-item.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/search-result-item.template.html
@@ -1,4 +1,8 @@
 <tr>
+    <% if (showManuscript) { %>
+    <td><%= result.manuscript %></td>
+    <% } %>
+    
     <td><%= result.folio %></td>
 
     <td>
@@ -9,7 +13,9 @@
     </td>
 
     <% _.forEach(infoFields, function (field) { %>
+    <% if (field.type != 'manuscript') { %>
     <td><%= result[field.type] %></td>
+    <% } %>
     <% }); %>
 </tr>
 


### PR DESCRIPTION
When `manuscript` is an additional field returned by search (in other words, when the search is not filtered by the manuscript), make it the first column in the search results. This currently applies to the search results obtained in the Search modal window, but not in the search on the manuscript detail page, the latter being already filtered by the manuscript being shown.

Closes #844 