### PR TITLE
Make Cantus ID searchable

### DIFF
--- a/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
+++ b/nginx/public/node/frontend/public/js/app/manuscript-detail/folio/chant-record.template.html
@@ -2,7 +2,7 @@
 <p>
 <% } %>
 <% if (cantus_id) { %>
-<b>Cantus ID:</b> <%= cantus_id %>
+<b>Cantus ID:</b> <a href = "https://cantusindex.org/id/<%= cantus_id %>" target = "_blank"><%= cantus_id %></a>
 <% } %>
 <% if (cdb_link_url) { %>
 (<a href = <%= cdb_link_url %> target = "_blank" rel = "noopener noreferrer">Visit record in Cantus Database</a>)

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/ChantSearchProvider.js
@@ -23,7 +23,8 @@ var KNOWN_FIELDS = [
     {type: "genre", "name": "Genre"},
     {type: "office", "name": "Office"},
     {type: "differentia", "name": "Differentia"},
-    {type: "differentiae_database", "name": "Differentiae Database"}
+    {type: "differentiae_database", "name": "Differentiae Database"},
+    {type: "cantus_id", "name": "Cantus ID"},
 ];
 
 var INITIAL_LOAD_CUTOFF = 100;
@@ -56,7 +57,8 @@ export default Marionette.Object.extend({
         "differentia",
         "finalis",
         "folio",
-        "differentiae_database"
+        "differentiae_database",
+        "cantus_id"
     ],
 
     /**

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/SearchResultCollectionView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/SearchResultCollectionView.js
@@ -57,6 +57,11 @@ export default Marionette.CompositeView.extend({
 
         this.listenTo(this.searchParameters, 'change:sortBy change:reverseSort', this._triggerSortingChanged);
         this.listenTo(this.searchParameters, 'change:query change:field', this._resetScrolling);
+
+        // Show manuscript column if additional fields requested in search
+        // includes the manuscript (in other words, if we are doing a 
+        // cross-manuscript search)
+        this.showManuscript = _.some(this.getOption("infoFields"), field => field.type === 'manuscript');
     },
 
     childViewOptions: function ()
@@ -64,7 +69,8 @@ export default Marionette.CompositeView.extend({
         return {
             searchType: this.searchParameters.get('field'),
             query: this.searchParameters.get('query'),
-            infoFields: this.getOption('infoFields')
+            infoFields: this.getOption('infoFields'),
+            showManuscript: this.showManuscript
         };
     },
 
@@ -215,7 +221,8 @@ export default Marionette.CompositeView.extend({
     templateHelpers: function()
     {
         return {
-            infoFields: _.toArray(this.getOption('infoFields'))
+            infoFields: _.toArray(this.getOption('infoFields')),
+            showManuscript: this.showManuscript
         };
     }
 });

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/SearchResultItemView.js
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/SearchResultItemView.js
@@ -117,6 +117,7 @@ export default Marionette.ItemView.extend({
 
         return {
             infoFields: infoFields,
+            showManuscript: this.getOption('showManuscript'),
             searchType: searchType,
             result: this.model.getFormattedData(searchType, query),
             isVolpianoSearch: searchType === 'volpiano' || searchType === 'volpiano_literal',

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/search-result-collection.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/search-result-collection.template.html
@@ -2,6 +2,12 @@
     <table class="table table-condensed result-list child-container">
         <thead>
             <tr>
+                <% if (showManuscript) { %>
+                <th> 
+                    <a href="#">Manuscript</a>
+                    <span class="search-caret"></span>
+                </th>
+                <% } %>
                 <th>
                     <a href="#">Folio</a>
                     <span class="search-caret"></span>
@@ -13,10 +19,12 @@
                 </th>
 
                 <% _.forEach(infoFields, function (field) { %>
+                <% if (field.type != 'manuscript') { %>
                 <th>
                     <a href="#"><%= field.name %></a>
                     <span class="search-caret"></span>
                 </th>
+                <% } %>
                 <% }); %>
             </tr>
         </thead>

--- a/nginx/public/node/frontend/public/js/app/search/chant-search/search-result-item.template.html
+++ b/nginx/public/node/frontend/public/js/app/search/chant-search/search-result-item.template.html
@@ -1,4 +1,8 @@
 <tr>
+    <% if (showManuscript) { %>
+    <td><%= result.manuscript %></td>
+    <% } %>
+    
     <td><%= result.folio %></td>
 
     <td>
@@ -9,7 +13,9 @@
     </td>
 
     <% _.forEach(infoFields, function (field) { %>
+    <% if (field.type != 'manuscript') { %>
     <td><%= result[field.type] %></td>
+    <% } %>
     <% }); %>
 </tr>
 

--- a/solr/solr/cantus_ultimus_1/conf/schema.xml
+++ b/solr/solr/cantus_ultimus_1/conf/schema.xml
@@ -40,7 +40,7 @@
     <field name="folio_id" type="int" indexed="true" stored="true" />
     <field name="image_uri" type="string" indexed="true" stored="true"/>
     <field name="sequence" type="int" indexed="true" stored="true" />
-    <field name="cantus_id" type="text_general" indexed="true" stored="true" />
+    <field name="cantus_id" type="string" indexed="true" stored="true" />
     <field name="cdb_uri" type="text_general" indexed="true" stored="true" />
     <field name="feast" type="string" indexed="true" stored="true" />
     <field name="feast_date" type="text_general" indexed="true" stored="true" multiValued="false" />
@@ -130,6 +130,7 @@
     <copyField source="folio" dest="folio_t_hidden" />
     <copyField source="incipit" dest="incipit_t_hidden" />
     <copyField source="volpiano" dest="volpiano_literal" />
+    <copyField source="cantus_id" dest="cantus_id_t_hidden" />
 
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" />


### PR DESCRIPTION
Makes Cantus ID's searchable in Cantus Ultimus. Also, on the chant metadata panel, makes the Cantus ID (if it exists) into a clickable link to Cantus Index.

Closes #816. 

Note that #820 is still relevant here...this does not change what fields are show in the results, which means that while CantusID's can be searched after this PR, Cantus ID will not currently show up in the results table, just on the chant detail panel that accordions open upon navigating to the chant.