### PR TITLE
Rewrite SearchNotationView for new OMR search

### DIFF
--- a/app/public/cantusdata/helpers/mei_processing/mei_parsing_types.py
+++ b/app/public/cantusdata/helpers/mei_processing/mei_parsing_types.py
@@ -142,7 +142,7 @@ class NgramDocument(TypedDict):
         type: The type of the document (corresponds to solr schema's type field)
     """
 
-    location: str
+    location_json: str
     pitch_names: str
     contour: str
     semitone_intervals: str

--- a/app/public/cantusdata/helpers/mei_processing/mei_tokenizer.py
+++ b/app/public/cantusdata/helpers/mei_processing/mei_tokenizer.py
@@ -5,7 +5,7 @@ can then be indexed by a search engine (i.e. for this project, Solr).
 """
 
 import uuid
-from typing import List, Tuple, Optional, Never, Union
+from typing import List, Tuple, Optional
 from .mei_parser import MEIParser
 from .mei_parsing_types import (
     Neume,
@@ -88,7 +88,7 @@ class MEITokenizer(MEIParser):
         ]
         location: str = stringify_bounding_boxes(combine_bounding_boxes(zones_with_sys))
         return {
-            "location": location,
+            "location_json": location,
             "pitch_names": pitch_names,
             "contour": contour,
             "semitone_intervals": intervals,

--- a/app/public/cantusdata/helpers/search_utils.py
+++ b/app/public/cantusdata/helpers/search_utils.py
@@ -25,7 +25,7 @@ def validate_query(q: list[str], q_type: str) -> bool:
     match q_type:
         case "neume_names":
             return all(neume in VALID_NEUME_NAME_WORDS for neume in q)
-        case "pitch_names" | "pitch_names_invariant":
+        case "pitch_names" | "pitch_names_transposed":
             return all(pitch in "abcdefg" for pitch in q)
         case "contour":
             return all(contour in "udr" for contour in q)

--- a/app/public/cantusdata/test/core/helpers/mei_processing/test_mei_tokenizer.py
+++ b/app/public/cantusdata/test/core/helpers/mei_processing/test_mei_tokenizer.py
@@ -145,7 +145,7 @@ class MEITokenizerTestCase(TestCase):
         # <zone xml:id="zone-0000002089367816" ulx="5104" uly="7774" lrx="5175" lry="7824"/>
         with self.subTest("First 1-gram"):
             expected_1gram: NgramDocument = {
-                "location": json.dumps(
+                "location_json": json.dumps(
                     [{"ulx": 2608, "uly": 2399, "width": 70, "height": 49}]
                 ),
                 "pitch_names": "d",
@@ -156,7 +156,7 @@ class MEITokenizerTestCase(TestCase):
             self.assertEqual(expected_1gram, ngram_docs_1_2[0])
         with self.subTest("Ngram of first 3 neumes"):
             expected_3gram: NgramDocument = {
-                "location": json.dumps(
+                "location_json": json.dumps(
                     [{"ulx": 2608, "uly": 2292, "width": 477, "height": 201}]
                 ),
                 "neume_names": "punctum_clivis_punctum",
@@ -170,7 +170,7 @@ class MEITokenizerTestCase(TestCase):
             # This 3-gram is constructed from the second three
             # pitches of the sample above.
             pitch_3gram: NgramDocument = {
-                "location": json.dumps(
+                "location_json": json.dumps(
                     [{"ulx": 2725, "uly": 2292, "width": 360, "height": 201}]
                 ),
                 "pitch_names": "d_c_f",
@@ -190,7 +190,7 @@ class MEITokenizerTestCase(TestCase):
             # This 4-gram is constructed from the last three
             # pitches of the test document.
             pitch_3gram_1: NgramDocument = {
-                "location": json.dumps(
+                "location_json": json.dumps(
                     [{"ulx": 4811, "uly": 7724, "width": 364, "height": 150}]
                 ),
                 "pitch_names": "c_e_d",
@@ -209,7 +209,7 @@ class MEITokenizerTestCase(TestCase):
             # This 4-gram is constructed from the last four
             # pitches of the test document.
             pitch_4gram: NgramDocument = {
-                "location": json.dumps(
+                "location_json": json.dumps(
                     [{"ulx": 4750, "uly": 7724, "width": 425, "height": 150}]
                 ),
                 "pitch_names": "d_c_e_d",

--- a/app/public/cantusdata/test/core/helpers/test_search_utils.py
+++ b/app/public/cantusdata/test/core/helpers/test_search_utils.py
@@ -1,0 +1,54 @@
+from unittest import TestCase
+
+from cantusdata.helpers.search_utils import validate_query, get_transpositions
+
+
+class SearchUtilsTestCase(TestCase):
+    def test_validate_query(self) -> None:
+        with self.subTest("neume_names validation"):
+            valid_neume_names = ["punctum", "flexus", "porrectus"]
+            invalid_neume_names = ["punctum", "flexus", "not_a_neume_name"]
+            self.assertTrue(validate_query(valid_neume_names, "neume_names"))
+            self.assertFalse(validate_query(invalid_neume_names, "neume_names"))
+        with self.subTest("pitch_names validation"):
+            valid_pitch_names = ["a", "b", "c", "f", "g"]
+            invalid_pitch_names = ["d", "e", "x", "f"]
+            self.assertTrue(validate_query(valid_pitch_names, "pitch_names"))
+            self.assertFalse(validate_query(invalid_pitch_names, "pitch_names"))
+            self.assertTrue(validate_query(valid_pitch_names, "pitch_names_invariant"))
+            self.assertFalse(
+                validate_query(invalid_pitch_names, "pitch_names_invariant")
+            )
+        with self.subTest("contour validation"):
+            valid_contour = ["u", "d", "r"]
+            invalid_contour = ["u", "d", "s", "r"]
+            self.assertTrue(validate_query(valid_contour, "contour"))
+            self.assertFalse(validate_query(invalid_contour, "contour"))
+        with self.subTest("invalid query type"):
+            self.assertFalse(validate_query(["a", "b", "c"], "not_a_query_type"))
+
+    def test_get_transpositions(self) -> None:
+        with self.subTest("Transpositions of 'ga'"):
+            transpositions = get_transpositions(["g", "a"])
+            expected_transpositions = [
+                ["g", "a"],
+                ["a", "b"],
+                ["b", "c"],
+                ["c", "d"],
+                ["d", "e"],
+                ["e", "f"],
+                ["f", "g"],
+            ]
+            self.assertEqual(transpositions, expected_transpositions)
+        with self.subTest("Transpositions of 'fgae'"):
+            transpositions = get_transpositions(["f", "g", "a", "e"])
+            expected_transpositions = [
+                ["f", "g", "a", "e"],
+                ["g", "a", "b", "f"],
+                ["a", "b", "c", "g"],
+                ["b", "c", "d", "a"],
+                ["c", "d", "e", "b"],
+                ["d", "e", "f", "c"],
+                ["e", "f", "g", "d"],
+            ]
+            self.assertEqual(transpositions, expected_transpositions)

--- a/app/public/cantusdata/test/core/helpers/test_search_utils.py
+++ b/app/public/cantusdata/test/core/helpers/test_search_utils.py
@@ -15,9 +15,9 @@ class SearchUtilsTestCase(TestCase):
             invalid_pitch_names = ["d", "e", "x", "f"]
             self.assertTrue(validate_query(valid_pitch_names, "pitch_names"))
             self.assertFalse(validate_query(invalid_pitch_names, "pitch_names"))
-            self.assertTrue(validate_query(valid_pitch_names, "pitch_names_invariant"))
+            self.assertTrue(validate_query(valid_pitch_names, "pitch_names_transposed"))
             self.assertFalse(
-                validate_query(invalid_pitch_names, "pitch_names_invariant")
+                validate_query(invalid_pitch_names, "pitch_names_transposed")
             )
         with self.subTest("contour validation"):
             valid_contour = ["u", "d", "r"]

--- a/app/public/cantusdata/test/core/views/test_search_notation_view.py
+++ b/app/public/cantusdata/test/core/views/test_search_notation_view.py
@@ -1,14 +1,37 @@
-from rest_framework.test import APITransactionTestCase
+from rest_framework.test import APITestCase
 from django.core.management import call_command
 from django.urls import reverse
 
 from cantusdata.views.search_notation import SearchNotationView, NotationSearchException
+from cantusdata.models import Manuscript, Folio
 
 TEST_MEI_FILES_PATH = "cantusdata/test/core/helpers/mei_processing/test_mei_files"
 
 
-class TestSearchNotationView(APITransactionTestCase):
+class TestSearchNotationView(APITestCase):
     search_notation_view = SearchNotationView()
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """
+        In order for the index_manuscript_mei command
+        to run successfully, we need to create a Manuscript
+        and two Folio objects for the two folios for which
+        we have test data.
+        """
+        source = Manuscript.objects.create(
+            id=123723, name="Test Manuscript", siglum="TEST"
+        )
+        Folio.objects.create(
+            manuscript=source,
+            number="001r",
+            image_uri="test_001r.jpg",
+        )
+        Folio.objects.create(
+            manuscript=source,
+            number="001v",
+            image_uri="test_001r.jpg",
+        )
 
     def setUp(self) -> None:
         call_command(

--- a/app/public/cantusdata/test/core/views/test_search_notation_view.py
+++ b/app/public/cantusdata/test/core/views/test_search_notation_view.py
@@ -59,12 +59,12 @@ class TestSearchNotationView(APITestCase):
             )
             expected_query_string = "contour:u_d_u_r"
             self.assertEqual(query_string, expected_query_string)
-        # We add a separate subtest for a "pitch_names_invariant" query since it
+        # We add a separate subtest for a "pitch_names_transposed" query since it
         # has a slightly different logic (we get transpositions and chain them
         # together with ORs).
-        with self.subTest("Test pitch_names_invariant query"):
+        with self.subTest("Test pitch_names_transposed query"):
             query = "c d e"
-            query_type = "pitch_names_invariant"
+            query_type = "pitch_names_transposed"
             query_string = self.search_notation_view.create_query_string(
                 query, query_type
             )

--- a/app/public/cantusdata/test/core/views/test_search_notation_view.py
+++ b/app/public/cantusdata/test/core/views/test_search_notation_view.py
@@ -1,0 +1,131 @@
+from rest_framework.test import APITransactionTestCase
+from django.core.management import call_command
+from django.urls import reverse
+
+from cantusdata.views.search_notation import SearchNotationView, NotationSearchException
+
+TEST_MEI_FILES_PATH = "cantusdata/test/core/helpers/mei_processing/test_mei_files"
+
+
+class TestSearchNotationView(APITransactionTestCase):
+    search_notation_view = SearchNotationView()
+
+    def setUp(self) -> None:
+        call_command(
+            "index_manuscript_mei",
+            "123723",
+            "--min-ngram",
+            "1",
+            "--max-ngram",
+            "5",
+            "--mei-dir",
+            TEST_MEI_FILES_PATH,
+        )
+
+    def test_create_query_string(self) -> None:
+        with self.subTest("Test invalid query"):
+            with self.assertRaises(NotationSearchException):
+                self.search_notation_view.create_query_string(
+                    "a_b_q", q_type="pitch_names"
+                )
+        with self.subTest("Test valid query"):
+            query = "u   d U r  "
+            query_type = "contour"
+            query_string = self.search_notation_view.create_query_string(
+                query, query_type
+            )
+            expected_query_string = "contour:u_d_u_r"
+            self.assertEqual(query_string, expected_query_string)
+        # We add a separate subtest for a "pitch_names_invariant" query since it
+        # has a slightly different logic (we get transpositions and chain them
+        # together with ORs).
+        with self.subTest("Test pitch_names_invariant query"):
+            query = "c d e"
+            query_type = "pitch_names_invariant"
+            query_string = self.search_notation_view.create_query_string(
+                query, query_type
+            )
+            expected_query_string = "pitch_names:(c_d_e OR d_e_f OR e_f_g OR f_g_a OR g_a_b OR a_b_c OR b_c_d)"
+            self.assertEqual(query_string, expected_query_string)
+
+    def test_do_query(self) -> None:
+        with self.subTest("Test fields returned"):
+            # Test that, in general, the fields returned are as expected
+            expected_results_fields = [
+                "boxes",
+                "contour",
+                "semitones",
+                "pnames",
+            ]
+            results, _ = self.search_notation_view.do_query(
+                123723, "contour:u d u", 100, 0
+            )
+            results_fields = list(results[0].keys())
+            self.assertTrue(set(expected_results_fields).issubset(results_fields))
+            # Test a case where we know that neume names are returned and ensure
+            # that the "neumes" field is present in the results
+            results_neume_names, _ = self.search_notation_view.do_query(
+                123723, "neume_names:punctum", 100, 0
+            )
+            results_neume_names_fields = list(results_neume_names[0].keys())
+            expected_results_fields.append("neumes")
+            self.assertTrue(
+                set(expected_results_fields).issubset(results_neume_names_fields)
+            )
+        with self.subTest("Test rows and start parameters"):
+            results_rows_100_start_0, _ = self.search_notation_view.do_query(
+                123723, "neume_names:punctum", 100, 0
+            )
+            self.assertEqual(len(results_rows_100_start_0), 100)
+            results_rows_10_start_0, _ = self.search_notation_view.do_query(
+                123723, "neume_names:punctum", 10, 0
+            )
+            self.assertEqual(len(results_rows_10_start_0), 10)
+            self.assertEqual(results_rows_100_start_0[:10], results_rows_10_start_0)
+            results_rows_10_start_10, _ = self.search_notation_view.do_query(
+                123723, "neume_names:punctum", 10, 10
+            )
+            self.assertEqual(len(results_rows_10_start_10), 10)
+            self.assertEqual(results_rows_100_start_0[10:20], results_rows_10_start_10)
+        with self.subTest("Test manuscript_id parameter"):
+            _, num_found_123723 = self.search_notation_view.do_query(
+                123723, "neume_names:punctum", 100, 0
+            )
+            _, num_found_123724 = self.search_notation_view.do_query(
+                123724, "neume_names:punctum", 100, 0
+            )
+            self.assertGreater(num_found_123723, 0)
+            self.assertEqual(num_found_123724, 0)
+
+    def test_get(self) -> None:
+        url = reverse("search-notation-view")
+        with self.subTest("Test missing required parameters"):
+            params_no_manuscript: dict[str, str | int] = {
+                "q": "u d u",
+                "type": "contour",
+            }
+            response_no_manuscript = self.client.get(url, params_no_manuscript)
+            self.assertEqual(response_no_manuscript.status_code, 400)
+            params_no_type: dict[str, str | int] = {"q": "u d u", "manuscript": 123723}
+            response_no_type = self.client.get(url, params_no_type)
+            self.assertEqual(response_no_type.status_code, 400)
+            params_no_q: dict[str, str | int] = {
+                "type": "contour",
+                "manuscript": 123723,
+            }
+            response_no_q = self.client.get(url, params_no_q)
+            self.assertEqual(response_no_q.status_code, 400)
+        with self.subTest("Test response"):
+            params: dict[str, str | int] = {
+                "q": "u d u",
+                "type": "contour",
+                "manuscript": 123723,
+            }
+            response = self.client.get(url, params)
+            self.assertEqual(response.status_code, 200)
+            response_data = response.json()
+            self.assertIn("results", response_data)
+            self.assertIn("numFound", response_data)
+
+    def tearDown(self) -> None:
+        call_command("index_manuscript_mei", "123723", "--flush-index")

--- a/app/public/cantusdata/views/search_notation.py
+++ b/app/public/cantusdata/views/search_notation.py
@@ -81,7 +81,7 @@ class SearchNotationView(APIView):
         q_valid = validate_query(normalized_q_elems, q_type)
         if not q_valid:
             raise NotationSearchException("Invalid query.")
-        if q_type == "pitch_names_invariant":
+        if q_type == "pitch_names_transposed":
             transpositions = get_transpositions(normalized_q_elems)
             # Create a query string for the tranpositions:
             # e.g. if transpositions are [["a", "b" , "c"], "b","c","d"], etc.]

--- a/solr/solr/cantus_ultimus_1/conf/schema.xml
+++ b/solr/solr/cantus_ultimus_1/conf/schema.xml
@@ -67,7 +67,7 @@
     <field name="contour" type="string" indexed="true" stored="true" required="false" />
     <field name="semitone_intervals" type="string" indexed="true" stored="true" required="false" />
     <field name="intervals" type="string" indexed="true" stored="true" required="false" />
-    <field name="location" type="string" indexed="false" stored="true" required="false" />
+    <field name="location_json" type="string" indexed="false" stored="true" required="false" />
     <dynamicField name="*_strm" type="string" indexed="true" stored="true" multiValued="true" />
     <dynamicField name="*_stored" type="string" indexed="false" stored="true" />
     <!-- Some fields I made up to match the python file output -->

--- a/solr/solr/cantus_ultimus_1/conf/solrconfig.xml
+++ b/solr/solr/cantus_ultimus_1/conf/solrconfig.xml
@@ -73,6 +73,11 @@
             <int name="rows">10</int>
             <str name="df">text</str>
         </lst>
+        <lst name="appends">
+            <arr name="fl">
+                <str>location_json:[json]</str>
+            </arr>
+        </lst>
     </requestHandler>
 
     <!-- A request handler that returns indented JSON by default -->


### PR DESCRIPTION
The `SearchNotation` view was refactored and reorganized for clarity and to include type annotations and a variety of checks on the passed parameters. Searches for neume names, both transposed and fixed pitches, and contour are supported. The `text` and `incipit` searches were removed because they are handled by the normal search view. The `interval` search was removed for now because it has not yet been implemented in the MEI parsing and indexing. An issue to add it back has been created (#875).

One odd thing is that on the old version of OMR search, `Pitch` search did not search transpositions of pitches, while `Pitch (Invariant)` search did. See images. To me, that seems the wrong way around. I've kept this labeling that way in this PR, but I'm curious for @lucasmarchd01 and @annamorphism's opinion. UPDATE: The relevant places in this PR have been updated to that queries of `pitch_names` type do not search transpositions, while queries of type `pitch_names_transposed` do search transpositions.
![image](https://github.com/DDMAL/cantus/assets/11023634/c0e0238a-c1f4-4607-967b-8f627ee27fde)
 
![image](https://github.com/DDMAL/cantus/assets/11023634/50acd297-0ecb-4fae-953a-0ecf1850ab34)


The rewrite of the `SearchNotationView` necessitated the change of some functions in `search_utils.py`:
- a new function, `validate_query`, that tests whether or not a query string for a particular type of OMR search (neume names, pitches, etc.) is valid
- a renamed function, `transpose_up_unicode`, which was renamed from `transposeUp` and uses the unicode for note names to transpose a note up one step
- `get_transpositions`, which gets all diatonic transpositions of a given sequence of note names
Tests for these functions were added.

This PR introduces the use of the `json` transformer on the `location` field in solr. With this change, the solr server returns a json object in the location field (when parsed in python, this is then a dictionary), rather than a string of json that must then be separately parsed in python or javascript. This feature is added by modifying the solr config file and (for clarity) changing the name of the `location` field to `location_json`.

Closes #874.