### PR TITLE
Settings and dependabot fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       python-dependencies:
         patterns: 

--- a/app/public/cantusdata/settings.py
+++ b/app/public/cantusdata/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/dev/ref/settings/
 from pathlib import Path
 import os
 
-is_development = os.environ.get("DEVELOPMENT")
+is_development = os.environ.get("DEVELOPMENT") == "True"
 is_production = not is_development
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   app:
     build:


### PR DESCRIPTION
This PR addresses two minor issues:

1. Fixes an issue in how the "DEVELOPMENT" environment variable was read in the django settings.py file. The result of the `os.environ.get` call is alway a string, so we need to check it against a string in order to get a boolean value.
2. It has dependabot check for updates monthly rather than weekly. Since we look for patch updates, this was resulting in a lot of dependabot PR's being opened and then closed much more frequently than we actually update our servers. 

It also removes an unused `version` parameter in the `docker-compose.yml` file.