### PR TITLE
updated base domain for IA IIIF URL (removed 'lab')

### DIFF
--- a/app/public/data_dumps/manifests.csv
+++ b/app/public/data_dumps/manifests.csv
@@ -9,7 +9,7 @@ A-KN 589,https://manuscripta.at/diglit/iiif/AT5000-589/manifest.json
 B-DEa 9,https://lib.is/IE9129581/manifest
 B-Gu Hs BKT.006,https://adore.ugent.be/IIIF/manifests/archive.ugent.be:082FD364-C35A-11DF-A9D6-99EF78F64438
 CDN-Hsmu M2149.L4,https://lib.is/IE9434868/manifest
-CDN-Mlr MS 073,https://iiif.archivelab.org/iiif/McGillLibrary-rbsc_ms-medieval-073-18802/manifest.json
+CDN-Mlr MS 073,https://iiif.archive.org/iiif/3/McGillLibrary-rbsc_ms-medieval-073-18802/manifest.json
 CH-E 121,https://www.e-codices.unifr.ch/metadata/iiif/sbe-0121/manifest.json 
 CH-E 611,http://www.e-codices.unifr.ch/metadata/iiif/sbe-0611/manifest.json 
 CH-Fco Ms. 2,https://www.e-codices.unifr.ch/metadata/iiif/fcc-0002/manifest.json


### PR DESCRIPTION
changed https://iiif.archivelab.org/iiif/3/McGillLibrary-rbsc_ms-medieval-073-18802/manifest.json to https://iiif.archive.org/iiif/3/McGillLibrary-rbsc_ms-medieval-073-18802/manifest.json