### PR TITLE
feat: add manuscript viewer compatibility warning systemAdd viewer_wa…

### DIFF
--- a/app/public/cantusdata/management/commands/set_viewer_warnings.py
+++ b/app/public/cantusdata/management/commands/set_viewer_warnings.py
@@ -24,12 +24,10 @@ class Command(BaseCommand):
             salzinnes.save()
             self.stdout.write(
                 self.style.SUCCESS(
-                    f'Successfully updated warning for manuscript: {salzinnes}'
+                    f"Successfully updated warning for manuscript: {salzinnes}"
                 )
             )
         else:
             self.stdout.write(
-                self.style.WARNING(
-                    'Salzinnes manuscript not found in database'
-                )
+                self.style.WARNING("Salzinnes manuscript not found in database")
             )

--- a/app/public/cantusdata/management/commands/set_viewer_warnings.py
+++ b/app/public/cantusdata/management/commands/set_viewer_warnings.py
@@ -1,0 +1,35 @@
+"""
+Management command to set the viewer warning for manuscripts with incompatible manifests.
+"""
+
+from django.core.management.base import BaseCommand
+from cantusdata.models.manuscript import Manuscript
+
+
+class Command(BaseCommand):
+    help = "Set viewer warnings for manuscripts with incompatible manifest versions"
+
+    def handle(self, *args, **options):
+        # Update Salzinnes manuscript with incompatible manifest warning
+        salzinnes = Manuscript.objects.filter(
+            manifest_url="https://lib.is/IE9434868/manifest"
+        ).first()
+
+        if salzinnes:
+            salzinnes.viewer_warning = (
+                "This manuscript's manifest is currently using an old presentation version "
+                "and is not compatible with our viewer. A fix is in progress; until then, "
+                "this manuscript cannot be viewed here."
+            )
+            salzinnes.save()
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'Successfully updated warning for manuscript: {salzinnes}'
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.WARNING(
+                    'Salzinnes manuscript not found in database'
+                )
+            )

--- a/app/public/cantusdata/migrations/0005_manuscript_viewer_warning.py
+++ b/app/public/cantusdata/migrations/0005_manuscript_viewer_warning.py
@@ -1,0 +1,22 @@
+# Generated migration for adding viewer_warning field to Manuscript model
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cantusdata", "0004_alter_neumeexemplar_options_neumeexemplar_order"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="manuscript",
+            name="viewer_warning",
+            field=models.TextField(
+                blank=True,
+                null=True,
+                help_text="Optional warning message to display if the manuscript viewer has compatibility issues",
+            ),
+        ),
+    ]

--- a/app/public/cantusdata/models/manuscript.py
+++ b/app/public/cantusdata/models/manuscript.py
@@ -48,6 +48,11 @@ class Manuscript(models.Model):
     cantus_url = models.CharField(max_length=255, blank=True, null=True)
     csv_export_url = models.CharField(max_length=255, blank=True, null=True)
     manifest_url = models.CharField(max_length=255, blank=True, null=True)
+    viewer_warning = models.TextField(
+        blank=True,
+        null=True,
+        help_text="Optional warning message to display if the manuscript viewer has compatibility issues"
+    )
 
     # Store the initial value of public in order to detect any changes.
     def __init__(self, *args, **kwargs):

--- a/app/public/cantusdata/models/manuscript.py
+++ b/app/public/cantusdata/models/manuscript.py
@@ -51,7 +51,7 @@ class Manuscript(models.Model):
     viewer_warning = models.TextField(
         blank=True,
         null=True,
-        help_text="Optional warning message to display if the manuscript viewer has compatibility issues"
+        help_text="Optional warning message to display if the manuscript viewer has compatibility issues",
     )
 
     # Store the initial value of public in order to detect any changes.

--- a/nginx/app/src/js/manuscript-detail/manuscript.template.html
+++ b/nginx/app/src/js/manuscript-detail/manuscript.template.html
@@ -1,6 +1,12 @@
 <div id="toolbar-row">
     <div class="toolbar-things"></div>
 </div>
+<% if (viewer_warning) { %>
+<div class="alert alert-warning alert-dismissible fade show" role="alert" style="margin: 1rem; margin-bottom: 0;">
+    <strong>Notice:</strong> <%- viewer_warning %>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+<% } %>
 <div class="manuscript-columns propagate-height">
     <div id="diva-column" class="propagate-height"></div>
     <div id="manuscript-data-column" class="propagate-height">


### PR DESCRIPTION
…rning field to Manuscript model with UI banner support. Set warning for Salzinnes manuscript due to manifest incompatibility. Includes migration, template updates, and management command. This is in response to issue #937. In future, a more responsive version for detecting upstream versions should be implemented. Additional banner will be deployed warning about slowness for CDN-MS Medieval 0073.

Hanwen and Yinan I've tagged y'all just to get another pair of eyes on this, and because I believe it needs to be staged on the django development server and then pushed to prod from there (?). 